### PR TITLE
Fix branch-protection hook: allow safe delete (git branch -d)

### DIFF
--- a/templates/hooks/branch-protection.sh
+++ b/templates/hooks/branch-protection.sh
@@ -61,8 +61,8 @@ if echo "$COMMAND" | grep -qiE 'git\s+push\s+.*--force'; then
   exit 2
 fi
 
-# Check for git branch -D (force delete branch)
-if echo "$COMMAND" | grep -qiE 'git\s+branch\s+-D\s'; then
+# Check for git branch -D (force delete branch) -- case-sensitive, -d (safe delete) is allowed
+if echo "$COMMAND" | grep -qE 'git\s+branch\s+-D\s'; then
   echo "BLOCKED by JitNeuro branch protection: force branch delete detected." >&2
   echo "This is destructive and requires the project owner's explicit permission." >&2
   exit 2


### PR DESCRIPTION
## Summary
- Branch-protection hook grep used `-qiE` (case-insensitive), which blocked both `-D` (force delete) and `-d` (safe delete)
- Changed to `-qE` (case-sensitive) so only force delete (`-D`) is blocked as intended
- Safe delete (`git branch -d`) is a normal git operation and should not be gated

## Test Plan
- [ ] `git branch -d <merged-branch>` succeeds (was previously blocked)
- [ ] `git branch -D <branch>` is still blocked by the hook
- [ ] `/verify` passes after deploying updated hook