### PR TITLE
feat: per-repo push-to-main override via mainPushAllowed

### DIFF
--- a/docs/hooks-guide.md
+++ b/docs/hooks-guide.md
@@ -47,10 +47,12 @@ Intercepts every Bash command before execution and blocks RED zone git operation
 
 | Command Pattern | Why Blocked |
 |-----------------|-------------|
-| `git push ... main/master` | Push to main requires explicit permission |
-| `git push --force` | Force push is destructive and irreversible |
+| `git push ... main/master` | Push to main requires explicit permission (unless repo is in `mainPushAllowed`) |
+| `git push --force` | Force push is destructive and irreversible (always blocked, no override) |
 | `git branch -D` | Force-deletes a branch without merge check |
 | `git reset --hard` | Discards all uncommitted work |
+
+**Per-repo override:** For local development repos and self-made internal tools where push-to-main is low risk (e.g., Vercel auto-deploys, no team review required), you can add the repo's full upstream URL to `mainPushAllowed` in jitneuro.json. The hook checks `git remote get-url origin` against this list before blocking. Force push is always blocked regardless of this setting.
 
 When a command is blocked, Claude receives the reason via stderr and will inform the user and ask for permission before retrying.
 
@@ -137,11 +139,14 @@ Located at `.claude/jitneuro.json`. Central config for JitNeuro version, hook be
 
 ```json
 {
-  "version": "0.1.2",
+  "version": "0.1.3",
   "hooks": {
     "preCompactBehavior": "block",
     "autosave": true,
     "protectedBranches": ["main", "master"],
+    "mainPushAllowed": [
+      "https://github.com/yourorg/your-repo.git"
+    ],
     "hookEvents": [...]
   }
 }
@@ -152,6 +157,7 @@ Located at `.claude/jitneuro.json`. Central config for JitNeuro version, hook be
 | `preCompactBehavior` | `block` | "block" halts compaction until user responds. "warn" lets it proceed. |
 | `autosave` | `true` | Write `_autosave.md` breadcrumb on session end. Set false to disable. |
 | `protectedBranches` | `["main", "master"]` | Branches that branch-protection hook blocks push to. |
+| `mainPushAllowed` | `[]` | Full git remote URLs allowed to push to protected branches without approval. Must match `git remote get-url origin` exactly. Use for local dev repos and self-made internal tools where push-to-main is low risk. Force push is always blocked. |
 
 Hook scripts read this config from `$(dirname "$HOOKS_DIR")/jitneuro.json` (one level up from hooks/).
 
@@ -241,7 +247,7 @@ JitNeuro hooks use grep patterns instead of jq to avoid external dependencies. I
 Default timeout is 10 seconds (5s for branch-protection). If a hook needs more time, increase the `timeout` value in settings.local.json. Keep timeouts short -- hooks block Claude's execution while running.
 
 **Hook blocks unexpectedly:**
-If branch-protection blocks a command you have permission to run, the user must explicitly tell Claude to proceed. The hook itself cannot be bypassed -- this is by design. The user confirms, and Claude can then run the command without the hook intercepting (or the hook must be temporarily removed).
+If branch-protection blocks a push to main that you want to allow, add the repo's full upstream URL to `mainPushAllowed` in jitneuro.json. The URL must match `git remote get-url origin` exactly -- check with `git -C /path/to/repo remote get-url origin`. This is designed for local development repos and self-made internal tools where the owner is the sole committer and push-to-main is low risk. For shared repos or repos with CI gates, keep the RED zone protection and use explicit per-push approval instead.
 
 ## Future Hooks (Planned)
 

--- a/templates/hooks/branch-protection.sh
+++ b/templates/hooks/branch-protection.sh
@@ -45,7 +45,7 @@ fi
 # Safety: if we still can't parse the command, block git operations rather than allow-all
 if [ -z "$COMMAND" ]; then
   # Check raw input for dangerous patterns as a fallback
-  if echo "$INPUT" | grep -qiE "git\s+push.*\b($PROTECTED)\b"; then
+  if echo "$INPUT" | grep -qiE "git\s+push.*\b($PROTECTED)(\s|$)"; then
     if ! echo "$INPUT" | grep -qiE 'git\s+push.*--force' && is_repo_allowed; then
       exit 0
     fi
@@ -66,7 +66,7 @@ fi
 
 # Check for git push to main or master (with or without origin/upstream)
 # Match: git push origin main, git push main, git push --force origin main, etc.
-if echo "$COMMAND" | grep -qiE "git\s+push\s+.*\b($PROTECTED)\b"; then
+if echo "$COMMAND" | grep -qiE "git\s+push\s+.*\b($PROTECTED)(\s|$)"; then
   # Allow if this repo's remote URL is in mainPushAllowed (force push still blocked below)
   if ! echo "$COMMAND" | grep -qiE 'git\s+push\s+.*--force' && is_repo_allowed; then
     exit 0

--- a/templates/hooks/branch-protection.sh
+++ b/templates/hooks/branch-protection.sh
@@ -10,11 +10,26 @@ CONFIG="$(dirname "$SCRIPT_DIR")/jitneuro.json"
 
 # Read protected branches from config (default: main, master)
 PROTECTED="main|master"
+ALLOWED_URLS=""
 if [ -f "$CONFIG" ]; then
   # Extract branch names from protectedBranches array
   BRANCHES=$(grep -o '"protectedBranches"[[:space:]]*:[[:space:]]*\[[^]]*\]' "$CONFIG" | grep -o '"[a-zA-Z0-9_-]*"' | tr -d '"' | tr '\n' '|' | sed 's/|$//')
   [ -n "$BRANCHES" ] && PROTECTED="$BRANCHES"
+  # Extract mainPushAllowed URLs (repos allowed to push to protected branches)
+  ALLOWED_URLS=$(grep -o '"mainPushAllowed"[[:space:]]*:[[:space:]]*\[[^]]*\]' "$CONFIG" | grep -o '"https://[^"]*"' | tr -d '"')
 fi
+
+# Check if current repo's remote is in the allowed list
+is_repo_allowed() {
+  [ -z "$ALLOWED_URLS" ] && return 1
+  local REMOTE_URL
+  REMOTE_URL=$(git remote get-url origin 2>/dev/null)
+  [ -z "$REMOTE_URL" ] && return 1
+  echo "$ALLOWED_URLS" | while IFS= read -r url; do
+    [ "$url" = "$REMOTE_URL" ] && exit 0
+  done
+  return $?
+}
 
 INPUT=$(cat)
 
@@ -31,6 +46,9 @@ fi
 if [ -z "$COMMAND" ]; then
   # Check raw input for dangerous patterns as a fallback
   if echo "$INPUT" | grep -qiE "git\s+push.*\b($PROTECTED)\b"; then
+    if ! echo "$INPUT" | grep -qiE 'git\s+push.*--force' && is_repo_allowed; then
+      exit 0
+    fi
     echo "BLOCKED by JitNeuro branch protection: git push to protected branch detected (fallback parser)." >&2
     echo "Protected branches: $PROTECTED. This requires the project owner's explicit permission." >&2
     exit 2
@@ -49,6 +67,10 @@ fi
 # Check for git push to main or master (with or without origin/upstream)
 # Match: git push origin main, git push main, git push --force origin main, etc.
 if echo "$COMMAND" | grep -qiE "git\s+push\s+.*\b($PROTECTED)\b"; then
+  # Allow if this repo's remote URL is in mainPushAllowed (force push still blocked below)
+  if ! echo "$COMMAND" | grep -qiE 'git\s+push\s+.*--force' && is_repo_allowed; then
+    exit 0
+  fi
   echo "BLOCKED by JitNeuro branch protection: git push to protected branch is a RED zone action." >&2
   echo "Protected branches: $PROTECTED. This requires the project owner's explicit permission." >&2
   exit 2

--- a/templates/jitneuro.json
+++ b/templates/jitneuro.json
@@ -1,9 +1,12 @@
 {
-  "version": "0.1.2",
+  "version": "0.1.3",
   "hooks": {
     "preCompactBehavior": "block",
     "autosave": true,
     "protectedBranches": ["main", "master"],
+    "mainPushAllowed": [
+      "https://github.com/dstolts/jitai-35.git"
+    ],
     "hookEvents": [
       {
         "event": "PreCompact",
@@ -36,7 +39,8 @@
         "block": "Compaction blocked (exit 2). User must respond before compaction can proceed."
       },
       "autosave": "true = write _autosave.md on session end; false = skip",
-      "protectedBranches": "Branches that require explicit permission to push to"
+      "protectedBranches": "Branches that require explicit permission to push to",
+      "mainPushAllowed": "Full git remote URLs whose repos are allowed to push to protected branches without approval. Must match output of git remote get-url origin exactly."
     },
     "_configResolution": "Single-level config for v0.1.x. Future: multi-level with most-secure-wins."
   }


### PR DESCRIPTION
## Summary
- Add `mainPushAllowed` config to jitneuro.json for repos where push-to-main is GREEN
- Uses full git remote URLs (must match `git remote get-url origin` exactly)
- Designed for local dev repos and self-made internal tools (sole committer, low risk)
- Force push is always blocked regardless of this setting
- Fix false positive where branch names containing "main" (e.g., feature/main-push-allowed) were incorrectly blocked

## Files Changed
- `templates/jitneuro.json` -- new config field, version bump to 0.1.3
- `templates/hooks/branch-protection.sh` -- `is_repo_allowed()` + regex fix
- `docs/hooks-guide.md` -- config docs, use case, troubleshooting

## Test plan
- [ ] Push to main from a repo listed in mainPushAllowed -- should succeed
- [ ] Push to main from a repo NOT listed -- should be blocked
- [ ] Force push from an allowed repo -- should still be blocked
- [ ] Push to feature branch with "main" in the name -- should not be blocked