### PR TITLE
feat: consolidated session management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ JIT memory management framework for Claude Code -- persistent context across ses
 ## Key Paths
 | Path | Purpose |
 |------|---------|
-| templates/commands/ | Slash command templates (15 commands) |
+| templates/commands/ | Slash command templates (17 files: 12 commands + 5 shortcuts) |
 | templates/hooks/ | Hook script templates (4 hooks) |
 | templates/engrams/ | Engram templates + examples |
 | templates/rules/ | Path-scoped rule templates |
@@ -24,7 +24,8 @@ JIT memory management framework for Claude Code -- persistent context across ses
 | install.sh / install.ps1 | Installation scripts (workspace/project/user modes) |
 
 ## Key Components
-- 15 slash commands: save, load, learn, health, sessions, enterprise, status, dashboard, gitstatus, diff, audit, bundle, onboard, orchestrate, conversation-log
+- 12 commands: session, sessions, learn, health, gitstatus, diff, enterprise, audit, bundle, onboard, orchestrate, conversation-log
+- 5 shortcuts: save, load, pulse, status, dashboard (delegate to session/sessions based on preference)
 - 4 hooks: PreCompact save, SessionStart recovery, Branch protection, SessionEnd auto-save
 - Engram system: per-project deep context files (50-150 lines each)
 - Bundle system: domain knowledge files loaded on-demand via routing weights

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > This started because reloading context after every /clear got old.
 > If it helps you, share what you learn.
 
-**Status: v0.1.2 -- 15 commands, 4 hooks, install scripts**
+**Status: v0.1.3 -- 12 commands, 5 shortcuts, 4 hooks, install scripts**
 **GitHub:** [github.com/dstolts/jitneuro](https://github.com/dstolts/jitneuro)
 
 **JIT = Just In Time.** A framework for managing short-term and long-term memory
@@ -106,7 +106,7 @@ repos, use **user** mode so commands are available everywhere.
 
 ## What's Included
 
-- **15 slash commands** -- memory (/save, /load, /learn), governance (/enterprise, /audit, /verify), git (/gitstatus, /diff), context (/bundle, /orchestrate, /status, /dashboard), setup (/onboard, /sessions, convlog, /health)
+- **12 commands + 5 shortcuts** -- session (/session, /sessions), memory (/learn, /health, /bundle), governance (/enterprise, /audit), git (/gitstatus, /diff), setup (/onboard, /orchestrate, convlog, /verify). Shortcuts: /save, /load, /pulse, /status, /dashboard
 - **4 hooks** -- pre-compact save, session recovery, branch protection, auto-save
 - **5 rule templates** -- schema, tests, coverage, deployment, components
 - **Templates** -- brainstem CLAUDE.md, bundle example, engram example, context manifest
@@ -115,20 +115,34 @@ repos, use **user** mode so commands are available everywhere.
 
 ## Roadmap
 
-### v0.1.2 (Current) -- Memory Layer
+### v0.1.3 (Current) -- Session Management
+Consolidated session lifecycle: /session (current) and /sessions (all).
+Subcommands: new, save, load, pulse, switch, rename, dashboard.
+Numbered session lists, .current tracking, shortcut preference system,
+session tag rule for cross-terminal awareness.
+
+### v0.1.2 -- Memory Layer
 Bundles, engrams, routing weights, /save, /load, /learn, /health, /enterprise,
 orchestrator, session management, install scripts with auto-configuration.
 
-### Phase 2 -- Decision Frameworks
+### Phase 2 -- Decision Frameworks (The Brain)
 Phase 1 solves memory (what to know). Phase 2 adds structured decision-making
 patterns -- teaching Claude not just your project context, but your preferences
-and workflows:
+and workflows. The foundation for this already exists in /learn, which
+evaluates sessions and persists patterns to long-term memory. Phase 2 extends
+this into a full cognitive layer:
 
 - **Decision Models** -- structured frameworks for how to decide, not what to do
 - **Prediction Rules** -- anticipate what the user wants next
 - **Anti-Patterns** -- learned constraints from corrections
 - **Persona Weights** -- which expert voice for which task type
 - **Governance Rules Engine** -- structured config for branching, trust zones, deploy gates
+
+Note: The author's production instance runs hundreds of additional capabilities
+built on this framework that are not yet in the open-source release. The memory
+and neuro network layers are straightforward to package. The cognitive layer --
+"how to think like me" -- requires more abstraction work to generalize for
+distribution. These capabilities will be pushed as they are packaged.
 
 See [FEATURE-REQUESTS.md](FEATURE-REQUESTS.md) for detailed Phase 2 design.
 

--- a/docs/commands-reference.md
+++ b/docs/commands-reference.md
@@ -1,43 +1,71 @@
 # Commands Reference
 
-JitNeuro ships 15 slash commands organized into 5 categories. All commands are read-only unless explicitly noted.
+JitNeuro ships 12 commands and 5 shortcuts organized into 5 categories. All commands are read-only unless explicitly noted.
 
 ---
 
-## Memory Management
+## Session Management
 
-### /save <name>
-Checkpoint session state before /clear. Writes current context, active tasks, and working state to a named snapshot so nothing is lost when the conversation resets.
+### /session [new|save|load|pulse|switch|rename|dashboard]
+Manage the current session. Default (no subcommand) shows current session status, repos, dirty files, and next steps.
 
-- **Arguments:** `name` (required) -- identifier for the checkpoint
-- **Note:** Writes to `D:\Code\.claude\session-state\`
+- **Subcommands:**
+  - `new <name>` -- create fresh named session (checks for unsaved work first)
+  - `save <name>` -- checkpoint to disk
+  - `load <name|#>` -- restore from disk
+  - `pulse` -- re-read shared state from other sessions
+  - `switch <name|#>` -- save current + load another in one step
+  - `rename <new-name>` -- rename current session
+  - `dashboard` -- current session's blockers and NEEDS DAN items
 
-Example:
+- **Tracking:** Active session stored in `.claude/session-state/.current`
+- **Tag rule:** Every response ends with `[session: <name>]`
+
+Examples:
 ```
-/save sprint-blog-progress
+/session                     -- where am I, what's dirty, what's next
+/session new sprint-auth     -- start fresh (prompts to save existing)
+/session save                -- checkpoint current session
+/session load 3              -- load session #3 from last /sessions list
+/session pulse               -- what changed in other sessions since I last looked
+/session switch 2            -- save current, load #2
+/session rename sprint-auth-v2
+/session dashboard           -- blockers for THIS session only
 ```
-Saves the current session as "sprint-blog-progress". Confirmation shows files written and context captured.
 
 ---
 
-### /load <name>
-Restore session state after /clear. Rehydrates context, active tasks, and working state from a previously saved checkpoint.
+### /sessions [list|show|stale|clean|archive|delete|dashboard]
+Manage all session checkpoints. Default shows a numbered list with NEEDS DAN summary across all sessions and active work.
 
-- **Arguments:** `name` (required) -- identifier of the checkpoint to restore
+- **Subcommands:**
+  - `<number>` or `show <name|#>` -- show full detail
+  - `stale` -- list sessions >3 days old
+  - `clean` -- delete stale sessions (confirms first)
+  - `archive <name|#>` -- move to archive
+  - `delete <name|#>` -- delete (confirms first)
+  - `dashboard` -- aggregate NEEDS DAN across all sessions
 
-Example:
+- **Note:** Active session marked with `*` in list output
+
+Examples:
 ```
-/load sprint-blog-progress
+/sessions                    -- numbered list + NEEDS DAN summary
+/sessions 3                  -- show detail for session #3
+/sessions archive 4          -- archive session #4
+/sessions stale              -- which sessions are >3 days old
+/sessions clean              -- delete all stale (confirms first)
 ```
-Restores the "sprint-blog-progress" checkpoint. Claude resumes with full awareness of where you left off.
 
 ---
+
+## Memory
 
 ### /learn
 Evaluate the current session for long-term knowledge updates and run a memory health check. Proposes updates to engrams, bundles, and MEMORY.md based on what happened during the session.
 
 - **Arguments:** None
-- **Note:** Writes to engrams and bundles in `D:\Code\.claude\`
+- **Note:** Writes to engrams and bundles
 
 Example:
 ```
@@ -60,38 +88,23 @@ Returns a table of all memory components with status (current, stale, missing, c
 
 ---
 
-## Governance
+### /bundle <name>
+Load a specific context bundle on demand. Bundles are curated knowledge sets that give Claude deep domain knowledge for a task.
 
-### /enterprise
-Display consolidated governance rules, trust zones, and review gates. Surfaces the full DOE compliance framework in one view so you know exactly what requires approval and what runs freely.
-
-- **Arguments:** None
+- **Arguments:** `name` (required) -- bundle identifier
 
 Example:
 ```
-/enterprise
+/bundle infrastructure
 ```
-Shows trust zone table (GREEN/YELLOW/RED), approval workflow, branch rules, and sprint protocol in a single consolidated view.
-
----
-
-### /audit [repo]
-Scan one or all repos for security issues, git hygiene, and DOE compliance. Checks for exposed secrets, missing CLAUDE.md files, uncommitted changes, and framework conformance.
-
-- **Arguments:** `repo` (optional) -- specific repo name to audit; omit to scan all repos
-
-Example:
-```
-/audit auth-api
-```
-Scans auth-api for .env exposure, missing engrams, CLAUDE.md presence, git status, and guardrail compliance. Returns a pass/fail table with remediation steps.
+Loads the infrastructure bundle, giving Claude full awareness of servers, VMs, ports, and deploy patterns.
 
 ---
 
 ## Git Operations
 
 ### /gitstatus [fetch|dirty|behind|unpushed|repo]
-Cross-repo git comparison showing local vs uat vs main status. Gives a bird's-eye view of all repos or filters by condition.
+Cross-repo git comparison showing local vs uat vs main status.
 
 - **Arguments (all optional):**
   - `fetch` -- fetch remotes before comparing
@@ -104,12 +117,12 @@ Example:
 ```
 /gitstatus dirty
 ```
-Returns a table of all repos with uncommitted changes, showing branch name, modified file count, and last commit date.
+Returns a table of all repos with uncommitted changes.
 
 ---
 
 ### /diff [repo]
-Show changes since last push or main divergence. Summarizes what has changed in the working tree and staged files relative to the remote branch.
+Show changes since last push or main divergence.
 
 - **Arguments:** `repo` (optional) -- specific repo name; defaults to current repo
 
@@ -117,68 +130,42 @@ Example:
 ```
 /diff auth-api
 ```
-Shows a summary of all changed files in the auth-api repo since the last push, with line counts and change descriptions.
+Shows a summary of all changed files since the last push, with line counts and change descriptions.
 
 ---
 
-## Context Management
+## Governance
 
-### /bundle <name>
-Load a specific context bundle on demand. Bundles are curated knowledge sets (e.g., deploy pipeline, infrastructure details, API design patterns) that give Claude deep domain knowledge for a task.
-
-- **Arguments:** `name` (required) -- bundle identifier (e.g., `deploy`, `infrastructure`, `api-design`, `integrations`, `testing`)
-
-Example:
-```
-/bundle deploy
-```
-Loads the deploy bundle, giving Claude full awareness of the deployment pipeline, environment configs, and release process.
-
----
-
-### /orchestrate
-Auto-route tasks to agents with appropriate bundles. Analyzes the current request, determines which bundles and context are needed, and loads them automatically based on routing weights.
+### /enterprise
+Display consolidated governance rules, trust zones, and review gates.
 
 - **Arguments:** None
 
 Example:
 ```
-/orchestrate
+/enterprise
 ```
-Claude analyzes the pending task, selects relevant bundles (e.g., deploy + infrastructure for a cross-repo task), and loads them before proceeding.
+Shows trust zone table (GREEN/YELLOW/RED), approval workflow, branch rules, and sprint protocol.
 
 ---
 
-### /status
-Quick "where am I" snapshot. Shows current branch, dirty files, active sprint, and working context in a compact summary.
+### /audit [repo]
+Scan one or all repos for security issues, git hygiene, and DOE compliance.
 
-- **Arguments:** None
-
-Example:
-```
-/status
-```
-Returns: current repo, branch, uncommitted file count, active sprint name, and last checkpoint timestamp.
-
----
-
-### /dashboard
-Aggregate all NEEDS DAN items into one prioritized triage view. Pulls pending decisions, blockers, and approval requests from all active sprints and repos into a single actionable list.
-
-- **Arguments:** None
+- **Arguments:** `repo` (optional) -- specific repo; omit to scan all
 
 Example:
 ```
-/dashboard
+/audit auth-api
 ```
-Returns a prioritized table of items requiring attention: approvals, blockers, decisions, and review requests across all active work.
+Scans for .env exposure, missing engrams, CLAUDE.md presence, git status, and guardrail compliance.
 
 ---
 
 ## Setup and Maintenance
 
 ### /onboard <repo>
-Bootstrap a new repo into the DOE/JitNeuro framework. Creates CLAUDE.md guardrails, initializes engram, registers in MEMORY.md, and sets up the .claude directory structure.
+Bootstrap a new repo into the DOE/JitNeuro framework.
 
 - **Arguments:** `repo` (required) -- name of the repo to onboard
 - **Note:** Writes new files (CLAUDE.md, engram, MEMORY.md entry)
@@ -187,31 +174,46 @@ Example:
 ```
 /onboard NewProject
 ```
-Creates `D:\Code\NewProject\.claude\CLAUDE.md`, initializes `D:\Code\.claude\engrams\newproject-context.md`, adds the repo to the MEMORY.md project table, and confirms DOE compliance.
+Creates CLAUDE.md, initializes engram, registers in MEMORY.md, confirms DOE compliance.
 
 ---
 
-### /sessions
-List, inspect, and clean session checkpoints. Manages the saved states created by /save, showing age, size, and contents of each checkpoint.
+### /orchestrate
+Auto-route tasks to agents with appropriate bundles.
 
 - **Arguments:** None
 
 Example:
 ```
-/sessions
+/orchestrate
 ```
-Returns a table of all saved checkpoints with name, date, size, and a brief description. Offers to clean stale checkpoints older than 7 days.
+Analyzes the pending task, selects relevant bundles, and loads them before proceeding.
 
 ---
 
-### convlog [on|off|status]
-Toggle conversation logging to .logs/ directory. When enabled, full session transcripts are saved for audit and review purposes.
+### /conversation-log [on|off|status]
+Toggle conversation logging to .logs/ directory.
 
 - **Arguments:** `on`, `off`, or `status` (optional, defaults to `status`)
-- **Note:** No leading slash -- this is invoked as `convlog`, not `/convlog`
 
 Example:
 ```
-convlog on
+/conversation-log on
 ```
-Enables conversation logging. All subsequent messages are written to `D:\Code\.claude\.logs\` with timestamped filenames. Use `convlog status` to check current state.
+Enables conversation logging with timestamped filenames.
+
+---
+
+## Shortcuts
+
+These delegate to `/session` or `/sessions` based on the `shortcut_scope` preference in `.claude/session-state/.preferences`. Default scope: `session` (current).
+
+| Shortcut | Default target (session) | Alternate target (sessions) |
+|----------|--------------------------|----------------------------|
+| `/save <name>` | `/session save` | `/session save` (always current) |
+| `/load <name\|#>` | `/session load` | `/session load` (always current) |
+| `/pulse` | `/session pulse` | `/session pulse` (always current) |
+| `/status` | `/session` | `/sessions` |
+| `/dashboard` | `/session dashboard` | `/sessions dashboard` |
+
+Note: `/save`, `/load`, and `/pulse` always target the current session regardless of preference. Only `/status` and `/dashboard` switch scope.

--- a/templates/commands/dashboard.md
+++ b/templates/commands/dashboard.md
@@ -1,79 +1,14 @@
 # Dashboard
 
-Aggregate all BLOCKED items, pending approvals, and blockers into one
-prioritized view. Single triage list so the project owner can make decisions in one pass.
-
-## When to Use
-- Start of day to see what needs attention
-- When switching contexts to find the highest-priority item
-- Before a planning session to review open items
-- When the user asks "what needs my attention"
+Shortcut that delegates to `/session dashboard` or `/sessions dashboard` based on user preference.
 
 ## Instructions
 
 When invoked as `/dashboard`:
 
-### Step 1: Gather Sources
+1. Read `.claude/session-state/.preferences` for `shortcut_scope` setting
+   - If `session` (default): execute `/session dashboard` (current session blockers)
+   - If `sessions`: execute `/sessions dashboard` (all sessions aggregate NEEDS DAN)
+2. Follow all instructions in the target command
 
-Read these files (in parallel where possible):
-
-1. `.claude/bundles/active-work.md` -- BLOCKED section + current sprints
-2. `.claude/session-state/` -- all session files, check for stale/pending items
-3. Scan for `.HUB/Hub.md` or `.HUB/*.md` files in active repos:
-   - Search the workspace root for subdirectories containing `.HUB/` folders
-   - Check any repos listed in active-work that might have hub files
-
-### Step 2: Categorize Items
-
-Group all found items into categories:
-
-| Category | Priority | Description |
-|----------|----------|-------------|
-| BLOCKED | Highest | Items that cannot proceed without the project owner's input |
-| APPROVAL | High | Plans, PRs, pushes waiting for the project owner's go-ahead |
-| DECISION | Medium | Choices the project owner needs to make (architecture, priority, scope) |
-| REVIEW | Medium | Work completed that needs the project owner's eyes |
-| INFO | Low | Status updates the project owner should know about |
-
-### Step 3: Present Dashboard
-
-```
-== Dashboard == [date]
-
-BLOCKED (cannot proceed):
-  1. [item] -- [source file] -- [what's needed]
-
-APPROVAL NEEDED:
-  2. [item] -- [source file] -- [what to approve]
-  3. [item] -- [source file] -- [what to approve]
-
-DECISIONS:
-  4. [item] -- [source file] -- [options]
-
-REVIEW:
-  5. [item] -- [source file] -- [what to review]
-
-INFO:
-  - [status update]
-  - [status update]
-
-Active sprints: [count]
-Open sessions: [count] ([stale count] stale)
-Total items: [count]
-```
-
-### Step 4: Offer Quick Actions
-
-After presenting the dashboard:
-"Pick a number to focus on, or 'all' to work through the list."
-
-If the user picks a number, load the relevant context (bundle, session, hub file)
-and present the specific item with enough detail to make a decision.
-
-## Important
-- This is READ-ONLY. Never modifies any files.
-- Present items in priority order (BLOCKED first).
-- Include source file paths so the user can find the original context.
-- Keep descriptions to one line each -- detail on demand.
-- If no items found: "Dashboard clear. No items need your attention."
-- Hub files may not exist for all repos -- skip gracefully.
+This is a convenience shortcut. All logic lives in `/session dashboard` or `/sessions dashboard`.

--- a/templates/commands/load.md
+++ b/templates/commands/load.md
@@ -1,65 +1,14 @@
 # Load
 
-Restore working state after a context reset (/clear).
-This reloads short-term memory saved by the /save skill.
-
-## When to Use
-- Immediately after `/clear` to continue previous work
-- At session start when picking up from a previous session
-- After accidental context loss
+Shortcut for `/session load`. Delegates to the session command.
 
 ## Instructions
 
-When invoked as `/load <session-name>`:
+When invoked as `/load <name|#>`:
 
-1. **Determine which session to resume:**
-   - If user provided a name: read `.claude/session-state/<session-name>.md`
-   - If no name provided: list all files in `.claude/session-state/` with their
-     checkpoint dates and current task summaries. Ask user to pick one.
-   - If directory doesn't exist or is empty: "No checkpoints found. Starting fresh."
+1. Read `.claude/session-state/.preferences` for `shortcut_scope` setting
+   - If `session` (default): execute `/session load <name|#>`
+   - If `sessions`: execute `/session load <name|#>` (load always targets current session)
+2. Follow all instructions in the `/session load` section of session.md
 
-2. **Read the session state file:**
-   - Load the full session state
-   - Note which repos are involved (cross-repo sessions are normal)
-   - Note which bundles were active
-
-3. **Read the active bundles** listed in the session state:
-   - For each bundle listed, read `.claude/bundles/[bundle-name].md`
-   - Do NOT load bundles that aren't listed (context conservation)
-
-4. **Read `.claude/context-manifest.md`** for the full bundle index
-   - This provides awareness of available bundles without loading them all
-
-5. **Report to user:**
-   ```
-   Loaded: <session-name> (checkpointed [date])
-   Task: [current task]
-   Repos: [list of repos involved]
-   Loaded bundles: [list]
-   Available bundles: [list of unloaded]
-   Next steps:
-   1. [from session-state]
-   2. [from session-state]
-   ```
-
-6. Continue working from where the checkpoint left off.
-
-## Listing Sessions
-
-When invoked as `/load` with no name, show:
-
-```
-Active sessions:
-  auth-api-refactor            (2h ago)  Sprint-Auth-Refactor, US-003
-  checkout-bug-fix             (1d ago)  Sprint-Checkout-001, testing
-  dashboard-redesign           (3d ago)  Dashboard Phase 2 research
-Pick one, or start fresh.
-```
-
-## Important
-- Load ONLY the bundles listed in the session state
-- If the user wants different bundles, they can request them explicitly
-- Do NOT re-read files that aren't needed for the current task
-- Keep the main context thin -- use agents for heavy work
-- If session state is stale (more than 3 days old), mention it and ask if still relevant
-- Session states are cross-repo -- repos involved are listed explicitly
+This is a convenience shortcut. All logic lives in `/session load`.

--- a/templates/commands/pulse.md
+++ b/templates/commands/pulse.md
@@ -1,0 +1,14 @@
+# Pulse
+
+Shortcut for `/session pulse`. Re-read shared state from disk to sync this session with changes made by other sessions.
+
+## Instructions
+
+When invoked as `/pulse`:
+
+1. Read `.claude/session-state/.preferences` for `shortcut_scope` setting
+   - If `session` (default): execute `/session pulse`
+   - If `sessions`: execute `/session pulse` (pulse always targets current session)
+2. Follow all instructions in the `/session pulse` section of session.md
+
+This is a convenience shortcut. All logic lives in `/session pulse`.

--- a/templates/commands/save.md
+++ b/templates/commands/save.md
@@ -1,97 +1,14 @@
 # Save
 
-Save current working state before a context reset (/clear or /compact).
-This preserves short-term memory so it can be restored by the /load skill.
-
-## When to Use
-- Before `/clear` when switching tasks
-- Before `/clear` when context is getting full
-- Before `/compact` as insurance against aggressive compression
-- At logical breakpoints (feature complete, sprint boundary)
-- Before any destructive context operation
-
-## How It Works
-Checkpoint writes to DISK (`.claude/session-state/<name>.md`), which survives
-both `/clear` and `/compact`. After `/clear`, use `/load <name>` to reload.
-After `/compact`, the session file serves as a safety net -- if compaction
-dropped something important, the full state is still on disk.
-
-```
-/save checkout-bug-fix     <-- saves to disk
-/clear                           <-- wipes context (disk untouched)
-/load checkout-bug-fix         <-- reads from disk, reloads bundles
-```
+Shortcut for `/session save`. Delegates to the session command.
 
 ## Instructions
 
-When invoked as `/save <session-name>`:
+When invoked as `/save <name>`:
 
-1. **Determine session name:**
-   - If user provided a name, use it (lowercase, hyphens, task-descriptive)
-   - If no name provided, suggest one based on current work and ASK to confirm
-   - Name should describe the TASK, not the repo (cross-repo sessions are normal)
-   - Good: `auth-api-refactor`, `checkout-bug-fix`, `dashboard-redesign`
-   - Bad: `my-project`, `session1`, `work`
-   - **Multiple tasks in session:** If the session touched more than one distinct task,
-     ask ONE question: "This session touched [task A] and [task B]. Save as one
-     checkpoint or separate?" Then create accordingly.
+1. Read `.claude/session-state/.preferences` for `shortcut_scope` setting
+   - If `session` (default): execute `/session save <name>`
+   - If `sessions`: execute `/session save <name>` (save always targets current session)
+2. Follow all instructions in the `/session save` section of session.md
 
-2. **Gather current session state:**
-   - What task am I working on?
-   - Which repos are involved? (cross-repo is common)
-   - Which bundles are currently loaded/active?
-   - What files have been modified this session?
-   - What decisions were made that haven't been persisted?
-   - What are the immediate next steps?
-   - Any key findings or discoveries worth preserving?
-
-3. **Write state to `.claude/session-state/<session-name>.md`:**
-   - Create `.claude/session-state/` directory if it doesn't exist
-   ```markdown
-   # Session: <session-name>
-   **Checkpointed:** [current date/time]
-
-   ## Current Task
-   [task name and brief status]
-
-   ## Repos Involved
-   - [repo path] -- [what's happening here]
-
-   ## Active Bundles
-   - [bundle1.md] -- [why it's loaded]
-   - [bundle2.md] -- [why it's loaded]
-
-   ## Modified Files
-   - [repo/file:line] -- [what changed]
-
-   ## Key Decisions
-   - [decision and reasoning]
-
-   ## Pending / Unresolved
-   - [items awaiting input or follow-up]
-
-   ## Next Steps
-   1. [immediate next action]
-   2. [following action]
-
-   ## Key Findings
-   - [discoveries worth preserving across /clear]
-   ```
-
-4. **Confirm to user:**
-   - "Checkpoint saved to .claude/session-state/<session-name>.md"
-   - List repos involved and current task
-   - "Safe to /clear. Use `/load <session-name>` to reload."
-
-## Size Guidance
-- Target: 30-60 lines. Enough to fully resume, not a session transcript.
-- Under 30 lines: probably missing something (decisions? findings? file paths?)
-- Over 80 lines: too verbose. Summarize, don't replay.
-- Claude decides what matters based on the actual session. No rigid rules.
-
-## Important
-- Do NOT update MEMORY.md, bundles, or engrams during save (that's /learn's job)
-- Do NOT modify any code files
-- If the session file already exists, UPDATE it (preserve history of previous checkpoints as context)
-- Session names are cross-repo by design -- one task may touch multiple repos
-- After saving, suggest: "Run `/learn` first if you want to persist any learnings from this session."
+This is a convenience shortcut. All logic lives in `/session save`.

--- a/templates/commands/session.md
+++ b/templates/commands/session.md
@@ -1,0 +1,256 @@
+# Session
+
+Manage the current session. Shows status by default, with subcommands for lifecycle operations.
+
+## Commands
+
+Trigger on these patterns (case-insensitive):
+- `session` -- show current session status + blockers (alias: `status`)
+- `session new <name>` -- create a fresh named session
+- `session save <name>` -- checkpoint to disk (shortcut: `/save`)
+- `session load <name|#>` -- restore from disk (shortcut: `/load`)
+- `session pulse` -- re-read shared state from other sessions (shortcut: `/pulse`)
+- `session switch <name|#>` -- save current + load another in one step
+- `session rename <new-name>` -- rename current session
+- `session dashboard` -- current session blockers and NEEDS DAN items
+
+Numbers reference the last `/sessions` list output.
+
+## Current Session Tracking
+
+The active session name is stored in `.claude/session-state/.current` (one line, just the name).
+Updated by: `new`, `save`, `load`, `switch`, `rename`.
+Read by: default view, `pulse`, `dashboard`, and the session tag rule.
+
+## Session Tag Rule
+
+**Every response must end with `[session: <name>]`** where `<name>` comes from `.current`.
+If no active session: `[session: none]`.
+This is non-negotiable -- it prevents context confusion across terminals.
+
+## Shortcut Preference
+
+Read `.claude/session-state/.preferences` for `shortcut_scope` setting.
+- `session` (default): `/status`, `/dashboard`, `/save`, `/load`, `/pulse` -> `/session` subcommands
+- `sessions`: `/status`, `/dashboard` -> `/sessions` subcommands (save/load/pulse always stay `/session`)
+
+If `.preferences` doesn't exist, default to `session` scope.
+
+## Instructions
+
+### session (default) -- current session status
+
+1. Read `.claude/session-state/.current` to get active session name
+2. If no active session: "No active session. Run `/session new <name>` to start one."
+3. Read the session state file `.claude/session-state/<name>.md`
+4. Read `.claude/bundles/active-work.md` for sprint context
+5. For each repo listed in the session state:
+   - Run `git -C [repo_path] status --short` for dirty files
+   - Run `git -C [repo_path] branch --show-current` for current branch
+   - Run `git -C [repo_path] log --oneline -1` for last commit
+6. Display:
+
+```
+== Session: <name> == (checkpointed <age> ago)
+
+Task: [current task]
+Sprint: [active sprint if any]
+
+| Repo | Branch | Dirty | Last Commit |
+|------|--------|-------|-------------|
+| app  | uat    | 3     | abc1234 fix: comments |
+| api  | sprint | clean | def5678 feat: endpoints |
+
+Next steps:
+1. [from session state]
+2. [from session state]
+
+BLOCKED: [count] items needing attention
+```
+
+7. Flag issues: repos on main with dirty files, unpushed commits, behind remote
+
+### session new <name>
+
+1. Check `.current` for active session
+2. If active session exists:
+   - Read the session state file, check age of last checkpoint
+   - Check if session has unsaved state (files modified, decisions made)
+   - Prompt (one question, recommended first):
+     "Active session '<name>' (last saved <age> ago, <N> files modified). Save + learn before starting new? (save+learn / save only / skip)"
+   - If save+learn: run save flow, then suggest /learn
+   - If save only: run save flow
+   - If skip: proceed
+3. Create `.claude/session-state/<name>.md` with initial template:
+   ```markdown
+   # Session: <name>
+   **Checkpointed:** [current date/time]
+
+   ## Current Task
+   New session -- no task assigned yet.
+
+   ## Repos Involved
+   - (none yet)
+
+   ## Key Decisions
+   - (none yet)
+
+   ## Next Steps
+   - Awaiting direction
+   ```
+4. Write session name to `.current`
+5. Confirm: "Session '<name>' created."
+
+### session save <name>
+
+1. **Determine session name:**
+   - If name provided, use it (lowercase, hyphens, task-descriptive)
+   - If no name: read `.current`. If active session, use that name.
+   - If no name and no active session: suggest one based on current work, ASK to confirm
+   - **Multiple tasks:** If session touched more than one distinct task,
+     ask: "This session touched [task A] and [task B]. Save as one or separate?"
+
+2. **Gather current session state:**
+   - What task am I working on?
+   - Which repos are involved?
+   - Which bundles are currently loaded/active?
+   - What files have been modified this session?
+   - What decisions were made that haven't been persisted?
+   - What are the immediate next steps?
+   - Any key findings or discoveries worth preserving?
+
+3. **Write state to `.claude/session-state/<name>.md`:**
+   ```markdown
+   # Session: <name>
+   **Checkpointed:** [current date/time]
+
+   ## Current Task
+   [task name and brief status]
+
+   ## Repos Involved
+   - [repo path] -- [what's happening here]
+
+   ## Active Bundles
+   - [bundle1.md] -- [why it's loaded]
+
+   ## Modified Files
+   - [repo/file:line] -- [what changed]
+
+   ## Key Decisions
+   - [decision and reasoning]
+
+   ## Pending / Unresolved
+   - [items awaiting input or follow-up]
+
+   ## Next Steps
+   1. [immediate next action]
+   2. [following action]
+
+   ## Key Findings
+   - [discoveries worth preserving across /clear]
+   ```
+
+4. Write session name to `.current`
+5. Confirm: "Saved '<name>'. Safe to /clear. Use `/session load <name>` to reload."
+6. Suggest: "Run `/learn` first if this session had learnings worth persisting."
+
+**Size guidance:** Target 30-60 lines. Under 30 probably missing something. Over 80 too verbose.
+
+### session load <name|#>
+
+1. **Determine which session:**
+   - If name/number provided: resolve to session file
+   - If no name: read `.current`. If exists, load that.
+   - If no name and no `.current`: list sessions, ask user to pick
+   - If number: resolve from last `/sessions` list output
+
+2. **Read the session state file**
+
+3. **Read active bundles** listed in session state (only those listed)
+
+4. **Read `.claude/context-manifest.md`** for bundle awareness
+
+5. **Write session name to `.current`**
+
+6. **Report:**
+   ```
+   Loaded: <name> (checkpointed <date>)
+   Task: [current task]
+   Repos: [list]
+   Loaded bundles: [list]
+   Next steps:
+   1. [from session state]
+   ```
+
+7. If session is stale (>3 days), mention it and ask if still relevant
+
+### session pulse
+
+1. Read `.current` to identify active session
+2. Read shared state files in parallel:
+   - `.claude/bundles/active-work.md`
+   - All `.claude/session-state/*.md` (exclude archive/, _autosave.md)
+   - Hub.md files for repos in current session
+3. Compare to what's in current context
+4. Report:
+   ```
+   Pulse (date/time):
+     active-work.md  -- [unchanged | N changes detected]
+     sessions         -- [N active, new/removed since last check]
+     Hub.md (repo)    -- [unchanged | updated]
+
+   Changes:
+     - Sprint-X marked complete (was: in progress)
+     - New session "feature-y" appeared
+   ```
+5. If nothing changed: "Pulse -- all shared state unchanged."
+6. If active-work.md changed significantly, suggest `/bundle active-work`
+
+### session switch <name|#>
+
+1. Run `session save` flow for current session (auto-save, no name prompt needed)
+2. Prompt: "Learnings worth persisting before switching? (yes -> /learn / no -> switch now)"
+3. Run `session load` flow for target session
+4. Update `.current` to new session name
+
+### session rename <new-name>
+
+1. Read `.current` to get active session name
+2. If no active session: "No active session to rename."
+3. Rename `.claude/session-state/<old-name>.md` to `<new-name>.md`
+4. Update `.current` to new name
+5. Update the `# Session:` header inside the file
+6. Confirm: "Renamed '<old>' -> '<new>'."
+
+### session dashboard
+
+1. Read `.current` to get active session
+2. Read the session state file
+3. Read `.claude/bundles/active-work.md`
+4. Read Hub.md files for repos in this session only
+5. Filter for items related to THIS session's repos/sprint
+6. Display:
+   ```
+   == Session Dashboard: <name> ==
+
+   BLOCKED (cannot proceed):
+     1. [item] -- [source] -- [what's needed]
+
+   APPROVAL NEEDED:
+     2. [item] -- [source] -- [what to approve]
+
+   DECISIONS:
+     3. [item] -- [options]
+
+   Next steps:
+     1. [from session state]
+   ```
+7. If no items: "Session '<name>' is clear -- no blockers."
+
+## Important
+- Do NOT update MEMORY.md, bundles, or engrams during save (that's /learn's job)
+- Do NOT modify code files from any session subcommand
+- Session names are cross-repo by design
+- If session file already exists on save, UPDATE it (preserve previous context)
+- `.current` is the single source of truth for active session
+- Always end every response with `[session: <name>]`

--- a/templates/commands/sessions.md
+++ b/templates/commands/sessions.md
@@ -1,75 +1,106 @@
 # Sessions
 
-List, inspect, and manage checkpoint sessions.
+List, inspect, and manage all session checkpoints. Numbered output for quick selection.
 
 ## Commands
 
 Trigger on these patterns (case-insensitive):
-- `sessions` or `sessions list` -- list all sessions
-- `sessions show <name>` -- show full detail of one session
-- `sessions stale` -- list sessions older than 3 days
-- `sessions clean` -- delete stale sessions (asks confirmation first)
-- `sessions archive <name>` -- move to session-state/archive/
-- `sessions delete <name>` -- delete a session (asks confirmation first)
+- `sessions` or `sessions list` -- numbered list of all sessions + NEEDS DAN summary (alias: `dashboard`)
+- `sessions <number>` -- show full detail of session at that number
+- `sessions show <name|number>` -- show full detail
+- `sessions stale` -- list sessions >3 days old
+- `sessions clean` -- delete stale sessions (confirms first)
+- `sessions archive <name|number>` -- move to session-state/archive/
+- `sessions delete <name|number>` -- delete (confirms first)
+- `sessions dashboard` -- same as default (all-sessions aggregate view)
+- `sessions status` -- same as default
+
+Numbers are assigned by the most recent list output (sorted newest first).
+Anywhere a `<name>` is accepted, a `<number>` from the last list works too.
 
 ## Instructions
 
 ### sessions list (default)
 
-1. List all `.md` files in `.claude/session-state/` (exclude archive/ subdirectory)
-2. For each file, read the first 10 lines to extract:
+1. List all `.md` files in `.claude/session-state/` (exclude archive/, exclude _autosave.md)
+2. Sort by checkpoint date (newest first)
+3. For each file, read the first 15 lines to extract:
    - Checkpointed date
    - Current Task line
    - Repos Involved
-3. Display as table:
+4. Assign sequential numbers starting at 1
+5. Mark the active session (from `.current`) with `*`
+6. Display as numbered table:
 
 ```
-Sessions (5 active):
-  Name                          Age    Task                              Repos
-  auth-api-refactor             2h     Sprint-Auth-Refactor US-003        auth-api, checkout-frontend
-  checkout-bug-fix              1d     Sprint-Checkout-001 testing       auth-api
-  deploy-pipeline-update        1d     Deploy pipeline v2 rollout        data-pipeline
-  dashboard-redesign            3d     Dashboard Phase 2 research        marketing-site
-  mobile-onboarding             5d     Sprint-Mobile-001 spec            mobile-app
+Sessions (5 active):                              [* = current]
+  #  Name                          Age    Task                              Repos
+  1* auth-api-refactor             2h     Sprint-Auth-Refactor US-003       auth-api, jitai
+  2  checkout-bug-fix              1d     Sprint-Checkout-001 testing       auth-api
+  3  deploy-pipeline-update        1d     Deploy pipeline v2 rollout        data-pipeline
+  4  dashboard-redesign            3d     Dashboard Phase 2 research        marketing-site
+  5  mobile-onboarding             5d     Sprint-Mobile-001 spec            mobile-app
 ```
 
-4. If stale sessions exist (>3 days), note at bottom:
-   "2 sessions are stale (>3 days). Run `sessions stale` to review."
+7. Read `.claude/bundles/active-work.md` for NEEDS DAN / BLOCKED items
+8. Scan Hub.md files across active repos for additional blocked items
+9. Append aggregate summary:
 
-### sessions show <name>
+```
+NEEDS DAN:
+  - [BLOCKED] Sprint-Auth-Refactor: push to main approval needed
+  - [APPROVAL] Sprint-Checkout-001: plan review
+  - [DECISION] Blog platform: Ghost vs custom
 
-1. Read full `.claude/session-state/<name>.md`
-2. Display contents
+Pick a number to show details, or: sessions archive|delete <#>
+```
+
+10. If stale sessions exist (>3 days), note:
+    "2 sessions are stale (>3 days). Run `sessions stale` to review."
+11. If no NEEDS DAN items: omit that section
+
+### sessions show <name|number>
+
+1. Resolve name (if number, use last list assignment)
+2. Read full `.claude/session-state/<name>.md`
+3. Display contents
 
 ### sessions stale
 
 1. List only sessions with checkpoint date >3 days old
-2. For each, show name, age, task, and last next-step
-3. Suggest: "Run `sessions clean` to delete all stale, or `sessions delete <name>` for one."
+2. For each, show number, name, age, task, and last next-step
+3. Suggest: "Run `sessions clean` to delete all stale, or `sessions delete <#>` for one."
 
 ### sessions clean
 
 1. List all stale sessions (>3 days)
-2. Show each name and task
+2. Show each number, name, and task
 3. Ask confirmation: "Delete these N stale sessions? (yes/no)"
 4. On yes, delete the files
-5. Report what was deleted
+5. If active session (`.current`) is being deleted, clear `.current`
+6. Report what was deleted
 
-### sessions archive <name>
+### sessions archive <name|number>
 
-1. Create `.claude/session-state/archive/` if it doesn't exist
+1. Create `.claude/session-state/archive/` if needed
 2. Move `<name>.md` to `archive/<name>.md`
-3. Confirm: "Archived <name>. Still readable at session-state/archive/<name>.md"
+3. If archived session was active (`.current`), clear `.current`
+4. Confirm: "Archived <name>. Still readable at session-state/archive/<name>.md"
 
-### sessions delete <name>
+### sessions delete <name|number>
 
 1. Read the session file, show task and last checkpoint date
 2. Ask confirmation: "Delete session '<name>'? (yes/no)"
 3. On yes, delete the file
-4. Confirm: "Deleted <name>."
+4. If deleted session was active (`.current`), clear `.current`
+5. Confirm: "Deleted <name>."
 
 ## Important
 - Never delete without confirmation
 - Archive is preferred over delete for completed work (preserves history)
 - Stale threshold is 3 days -- adjustable per user preference
 - This skill is read-only except for clean/archive/delete operations
+- Number assignments are ephemeral -- they reset each time list runs
+- When user provides just a number (e.g., `sessions 3`), treat as `sessions show 3`
+- Active session marked with `*` in list output
+- Always end every response with `[session: <name>]`

--- a/templates/commands/status.md
+++ b/templates/commands/status.md
@@ -1,63 +1,14 @@
 # Status
 
-Quick "where am I" snapshot across repos. Answers the most common question
-after a break: what was I working on, what's dirty, what branch am I on.
-
-## When to Use
-- Start of a session to orient yourself
-- After switching between repos or tasks
-- Before /save to see what needs checkpointing
-- When the user asks "where was I"
+Shortcut that delegates to `/session` or `/sessions` based on user preference.
 
 ## Instructions
 
 When invoked as `/status`:
 
-### Step 1: Check Active Session State
+1. Read `.claude/session-state/.preferences` for `shortcut_scope` setting
+   - If `session` (default): execute `/session` (current session status)
+   - If `sessions`: execute `/sessions` (all sessions list + NEEDS DAN)
+2. Follow all instructions in the target command
 
-Read `.claude/session-state/` directory. List any sessions modified in the last 24 hours.
-If a recent session exists, note its task and repos.
-
-### Step 2: Check Active Work Bundle
-
-Read `.claude/bundles/active-work.md` for current sprint status and BLOCKED items.
-
-### Step 3: Scan Repos for Dirty State
-
-For each repo listed in the active session state (or MEMORY.md project table if no session):
-- Run `git -C [repo_path] status --short` to check for uncommitted changes
-- Run `git -C [repo_path] branch --show-current` to get current branch
-- Run `git -C [repo_path] log --oneline -1` to get last commit
-
-Only check repos that are marked "Active Dev" or "Active" in MEMORY.md.
-Skip repos marked "Maintenance" or "Active Docs" unless they appear in a recent session.
-
-### Step 4: Present Summary
-
-```
-== Status ==
-
-Last session: [name] ([time ago])
-Task: [current task from session state]
-
-| Repo | Branch | Dirty | Last Commit |
-|------|--------|-------|-------------|
-| my-app | uat | 3 files | abc1234 fix: blog comments |
-| my-api | sprint-blog-001 | clean | def5678 feat: comment endpoints |
-| my-tools | master | 5 files | ghi9012 docs: hook templates |
-
-Active sprint: [from active-work bundle]
-BLOCKED: [count] items (run /dashboard for full list)
-```
-
-### Step 5: Flag Issues
-
-- Repos on main/master with dirty files (should be on feature branch)
-- Repos with unpushed commits
-- Repos where local branch is behind remote
-
-## Important
-- This is READ-ONLY. Never modifies any files.
-- Keep it fast -- only check repos likely to be active.
-- If no session state exists, fall back to MEMORY.md project table.
-- Show max 10 repos. If more are dirty, summarize as "and N more".
+This is a convenience shortcut. All logic lives in `/session` or `/sessions`.

--- a/templates/session-state/.preferences
+++ b/templates/session-state/.preferences
@@ -1,0 +1,1 @@
+shortcut_scope: session


### PR DESCRIPTION
## Summary
- Consolidated /save, /load, /status, /dashboard into unified /session (current) and /sessions (all) commands
- Added /session subcommands: new, save, load, pulse, switch, rename, dashboard
- Added /sessions features: numbered lists, active session marker (*), NEEDS DAN aggregate summary
- Added .current file for active session tracking, .preferences for shortcut scope
- Created /pulse shortcut (neuro-branded cross-session state sync)
- Shortcuts (/save, /load, /pulse, /status, /dashboard) delegate based on preference
- 12 commands + 5 shortcuts (down from 15 standalone commands)
- Updated README roadmap with v0.1.3 and note about unpublished capabilities

## Files changed (11)
- New: session.md, pulse.md, .preferences
- Updated: sessions.md, save.md, load.md, status.md, dashboard.md, commands-reference.md, CLAUDE.md, README.md

## Test plan
- [x] /sessions numbered list renders correctly with * on active session
- [x] .current file tracks active session
- [x] /session default shows current session status with git info
- [x] /session pulse logic verified
- [x] Shortcut delegation reads .preferences
- [ ] /session new safe-exit flow (prompts save+learn)
- [ ] /session switch (save + load in one step)
- [ ] /session rename (file rename + .current update)