### PR TITLE
feat: enhance autosave hook to detect forgotten /save

### DIFF
--- a/docs/hooks-guide.md
+++ b/docs/hooks-guide.md
@@ -64,11 +64,26 @@ When a command is blocked, Claude receives the reason via stderr and will inform
 - **Script:** session-end-autosave.sh
 - **Timeout:** 10s
 
-Writes a minimal recovery breadcrumb when a session terminates. Captures: timestamp, exit reason, duration, working directory, and session ID. Written to `.claude/session-state/_autosave.md` (overwritten each time).
+Safety net for forgotten `/save`. When a session ends, this hook checks whether a `/save` was called during the session by comparing the active session file's modification time against the session duration.
 
-This is NOT a full `/save` -- it only records that a session ended and where. If you forgot to `/save` before exiting, this file confirms a session was active.
+**If /save was detected:** Writes a minimal "all clear" breadcrumb -- no action needed.
 
-**Why this matters:** If you close your terminal, lose connection, or just forget to checkpoint, this hook ensures there is always a trace of what was happening.
+**If /save was NOT detected:** Writes a warning breadcrumb with recovery info:
+- The active session name (from `.current`)
+- How long ago the last save was
+- The last known task and repos (extracted from the session file)
+- A `/load` command to restore the last checkpoint
+
+Written to `.claude/session-state/_autosave.md` (overwritten each time). Excluded from `/sessions` dashboard output.
+
+**Why this matters:** The most common way to lose context is forgetting to `/save` before closing the terminal. This hook detects that gap and tells the next session exactly what to recover.
+
+**Limitations:**
+- The SessionEnd event provides only 4 fields: reason, duration, cwd, session_id. It has NO access to conversation context. The hook cannot capture what you were actually working on -- only what the last `/save` recorded.
+- Save detection relies on file modification timestamps. If the system clock is wrong or the filesystem doesn't update mtime, detection may be inaccurate.
+- If no `/save` was ever called (no `.current` file, no session files), the breadcrumb can only report "none" for session name, task, and repos.
+- The hook reads the first 15 lines of the session file to extract task/repos. If the session file format changes or those fields are beyond line 15, extraction will miss them.
+- On Windows, `stat -c %Y` may not work depending on the bash environment. The hook falls back to `stat -f %m` (BSD/macOS), but if both fail, save detection defaults to "no" (safe fallback -- always warns).
 
 ## Configuration
 

--- a/templates/hooks/session-end-autosave.sh
+++ b/templates/hooks/session-end-autosave.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 # JitNeuro SessionEnd Auto-Save Hook
-# Writes a minimal recovery breadcrumb when session terminates.
-#
-# This is NOT a full /save -- it's a safety net that captures the bare minimum
-# so the next session knows what was happening if the user forgot to /save.
+# Safety net for forgotten /save. Detects whether a /save happened during
+# the session and writes a useful breadcrumb if not.
 #
 # The file is overwritten each time (it's a "last known state" marker, not a log).
 
@@ -12,6 +10,7 @@ CLAUDE_DIR="$(dirname "$SCRIPT_DIR")"
 CONFIG="$CLAUDE_DIR/jitneuro.json"
 SESSION_DIR="$CLAUDE_DIR/session-state"
 AUTOSAVE_FILE="$SESSION_DIR/_autosave.md"
+CURRENT_FILE="$SESSION_DIR/.current"
 
 # Check if autosave is disabled in config
 if [ -f "$CONFIG" ]; then
@@ -47,22 +46,76 @@ mkdir -p "$SESSION_DIR"
 # Get current timestamp
 TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S' 2>/dev/null || echo "unknown")
 
-cat > "$AUTOSAVE_FILE" <<EOF
+# Detect active session name from .current
+CURRENT_SESSION=""
+if [ -f "$CURRENT_FILE" ]; then
+  CURRENT_SESSION=$(cat "$CURRENT_FILE" | tr -d '[:space:]')
+fi
+
+# Check if the active session file was updated during this session
+# (i.e., did a /save happen recently?)
+SAVE_DETECTED="no"
+LAST_SAVE_AGE=""
+SESSION_TASK=""
+SESSION_REPOS=""
+if [ -n "$CURRENT_SESSION" ] && [ -f "$SESSION_DIR/$CURRENT_SESSION.md" ]; then
+  # Get session file modification time vs now (seconds)
+  if command -v stat >/dev/null 2>&1; then
+    FILE_MOD=$(stat -c %Y "$SESSION_DIR/$CURRENT_SESSION.md" 2>/dev/null || stat -f %m "$SESSION_DIR/$CURRENT_SESSION.md" 2>/dev/null)
+    NOW=$(date +%s 2>/dev/null)
+    if [ -n "$FILE_MOD" ] && [ -n "$NOW" ] && [ -n "$DURATION" ]; then
+      AGE=$((NOW - FILE_MOD))
+      # If session file was modified within the session duration, a /save happened
+      if [ "$AGE" -le "$DURATION" ] 2>/dev/null; then
+        SAVE_DETECTED="yes"
+      fi
+      # Human-readable age
+      AGE_MIN=$((AGE / 60))
+      if [ "$AGE_MIN" -lt 60 ]; then
+        LAST_SAVE_AGE="${AGE_MIN}m ago"
+      else
+        AGE_HR=$((AGE_MIN / 60))
+        LAST_SAVE_AGE="${AGE_HR}h ago"
+      fi
+    fi
+  fi
+  # Extract task and repos from session file (first 15 lines)
+  SESSION_TASK=$(head -15 "$SESSION_DIR/$CURRENT_SESSION.md" 2>/dev/null | grep -A1 "^## Current Task" | tail -1 | sed 's/^[[:space:]]*//')
+  SESSION_REPOS=$(head -15 "$SESSION_DIR/$CURRENT_SESSION.md" 2>/dev/null | grep -A5 "^## Repos Involved" | grep "^-" | sed 's/^- //' | sed 's/ --.*//' | tr '\n' ', ' | sed 's/,$//')
+fi
+
+# If save was detected during this session, write minimal breadcrumb
+if [ "$SAVE_DETECTED" = "yes" ]; then
+  cat > "$AUTOSAVE_FILE" <<EOF
 # Autosave (Safety Net)
+**Session ended:** $TIMESTAMP
+**Duration:** $DURATION_STR
+**Save detected:** yes (session: $CURRENT_SESSION)
+**Status:** No action needed -- /save was called during this session.
+EOF
+  exit 0
+fi
+
+# No save detected -- write a useful warning breadcrumb
+cat > "$AUTOSAVE_FILE" <<EOF
+# Autosave (Safety Net) -- NO SAVE DETECTED
 **Session ended:** $TIMESTAMP
 **Reason:** ${REASON:-unknown}
 **Duration:** $DURATION_STR
 **Working directory:** ${CWD:-unknown}
 **Session ID:** ${SESSION_ID:-unknown}
 
-## Note
-This is an auto-generated breadcrumb from the SessionEnd hook.
-It is NOT a full /save checkpoint -- it only records that a session ended.
+## WARNING: No /save detected this session
+The user may have forgotten to save before exiting.
 
-If the user forgot to /save before exiting, this file confirms a session
-was active. Use /load with a named session for full state recovery.
+**Last active session:** ${CURRENT_SESSION:-none}
+**Last save age:** ${LAST_SAVE_AGE:-unknown}
+**Last known task:** ${SESSION_TASK:-unknown}
+**Last known repos:** ${SESSION_REPOS:-unknown}
 
-Check for recent named sessions in this directory for proper checkpoints.
+## Recovery
+Run \`/load ${CURRENT_SESSION:-<name>}\` to restore the last checkpoint.
+That checkpoint may be stale -- review and update it with current work.
 EOF
 
 exit 0


### PR DESCRIPTION
## Summary
- Autosave hook now detects whether /save was called during the session by comparing session file mtime against session duration
- If no /save detected: writes WARNING breadcrumb with last session name, task, repos, and /load recovery command
- If /save was detected: writes minimal all-clear (no action needed)
- Documents limitations in hooks-guide.md (no conversation context access, timestamp-dependent detection, Windows stat fallback, 15-line extraction constraint)

## Files changed
- `templates/hooks/session-end-autosave.sh` -- enhanced hook logic
- `docs/hooks-guide.md` -- updated description + limitations section

## Test plan
- [ ] Exit a session without /save -- verify _autosave.md shows WARNING with session name, task, repos
- [ ] Exit a session after /save -- verify _autosave.md shows "No action needed"
- [ ] Exit a session with no .current file -- verify _autosave.md shows "none" for session fields