### PR TITLE
fix: add mandatory numbered prompt to sessions list

### DIFF
--- a/templates/commands/sessions.md
+++ b/templates/commands/sessions.md
@@ -58,6 +58,13 @@ Pick a number to show details, or: sessions archive|delete <#>
 10. If stale sessions exist (>3 days), note:
     "2 sessions are stale (>3 days). Run `sessions stale` to review."
 11. If no NEEDS DAN items: omit that section
+12. MANDATORY -- end the response with a plain text prompt. Do NOT use AskUserQuestion. Just print this line at the very end:
+
+```
+Enter a session # to open, or: show|archive|delete <#>, stale, clean
+```
+
+The user's next message will be a number or command. Never skip this prompt.
 
 ### sessions show <name|number>
 


### PR DESCRIPTION
## Summary
- Sessions list was not showing numbered entries or prompting user for selection
- Added step 12 (MANDATORY) to sessions command: plain text prompt after table display
- User can now type a number to open a session instead of typing the full name

## Test plan
- Run /sessions -- verify numbered table appears with prompt line at end
- Type a number -- verify correct session loads