### PR TITLE
feat: v0.1.4 -- per-session tracking, Cursor support, bundle limits, genericize owner refs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -12,6 +12,9 @@ See the DOE Framework spec in your organization's orchestration docs for the ful
 | YELLOW | Schema changes, new dependencies, API contracts, .env writes | Execute, report at checkpoint |
 | RED | Push to main, production deploy, delete files/branches, DB migrations | Stop and ask the project owner |
 
+## Generic Project Rule
+This is an open-source project. NEVER use owner-specific names (e.g., "Dan") in code, templates, docs, or PRs. Use "owner", "user", or "project owner" instead. All content must be generic and reusable by any adopter.
+
 ## Quality Standards
 - **Guardrails override goals.** If a task conflicts with a guardrail, the guardrail wins. Never bypass a guardrail to complete a task. Surface the conflict and ask the project owner.
 - ASCII only (no emojis, no special characters)

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ Thumbs.db
 *.swp
 *~
 
+# Internal project notes (per-machine, not shared)
+.HUB/
+
 # Ralph task runner runtime files (optional -- only needed if using ralph-tui)
 .ralph-tui/iterations/
 .ralph-tui/reports/

--- a/FEATURE-REQUESTS.md
+++ b/FEATURE-REQUESTS.md
@@ -88,7 +88,7 @@ sprints, during onboarding, or when planning cross-repo changes.
 Quick context snapshot: current branch per repo, dirty files, active sprint,
 last commit, what bundle is loaded. Answers "where was I" in 5 seconds.
 
-## FR-009: /dashboard Command (NEEDS DAN Aggregator)
+## FR-009: /dashboard Command (NEEDS OWNER Aggregator)
 **Priority:** Medium
 **Status:** Done (v0.1.1) -- deployed to D:\Code\.claude\commands\dashboard.md
 

--- a/FEATURE-REQUESTS.md
+++ b/FEATURE-REQUESTS.md
@@ -9,7 +9,7 @@ Light local agent (Node or PowerShell) that:
 - Kicks off Claude Code sessions via JitNeuro with the right bundles
 - Runs on a schedule (cron/Task Scheduler)
 - Each task gets its own session-state checkpoint
-- Reports results back to the todo list (pass/fail/needs-Dan)
+- Reports results back to the todo list (pass/fail/needs-owner)
 
 Use cases:
 - Nightly code reviews across repos
@@ -92,8 +92,8 @@ last commit, what bundle is loaded. Answers "where was I" in 5 seconds.
 **Priority:** Medium
 **Status:** Done (v0.1.1) -- deployed to D:\Code\.claude\commands\dashboard.md
 
-Aggregate all NEEDS DAN items from active-work bundle, hub.md files across repos,
-and pending approvals. Single prioritized list so Dan can triage in one view.
+Aggregate all NEEDS OWNER items from active-work bundle, hub.md files across repos,
+and pending approvals. Single prioritized list so the owner can triage in one view.
 
 ## FR-010: /audit Command (Repo Hygiene)
 **Priority:** Medium
@@ -256,11 +256,11 @@ New directory: `.claude/governance/`
 ```
 | Repo | Branch | Policy | Approver |
 |------|--------|--------|----------|
-| * | main | RED (ask Dan) | Dan |
+| * | main | RED (ask owner) | owner |
 | * | uat | GREEN (push freely) | auto |
 | * | sprint-* | GREEN (push freely) | auto |
 | * | hotfix-* | YELLOW (push, report) | auto |
-| jitai | prod | RED (ask Dan) | Dan |
+| jitai | prod | RED (ask owner) | owner |
 ```
 
 **Merge policies**:
@@ -306,7 +306,7 @@ Configuration in CLAUDE.md or context-manifest.md:
 ```
 ## Identity
 - assistant_name: Neuro     # or Jit, or whatever the user wants
-- user_name: Dan             # used in session state, predictions, anti-patterns
+- user_name: Owner           # used in session state, predictions, anti-patterns
 ```
 
 Why this matters:

--- a/LAUNCH-TODO.md
+++ b/LAUNCH-TODO.md
@@ -48,7 +48,7 @@ Target: publish GitHub + blog + LinkedIn same day.
 - [ ] Key concepts: bundles, engrams, routing weights, /learn
 - [ ] "Get Started" CTA -> GitHub repo
 - [ ] Enterprise section: holistic review, multi-repo orchestration, Ralph integration
-- [ ] About/author section: Dan Stolts / jitai.co
+- [ ] About/author section: [Your Name] / [your-site]
 - [ ] #FirstMover badge
 - [ ] Deploy to Vercel (jitneuro.ai DNS)
 - [ ] Mobile responsive check
@@ -56,7 +56,7 @@ Target: publish GitHub + blog + LinkedIn same day.
 ## GitHub
 
 - [x] Initialize git remote (github.com/dstolts/jitneuro)
-- [ ] Push to main (RED -- needs Dan's explicit approval)
+- [ ] Push to main (RED -- needs owner's explicit approval)
 - [ ] Verify README renders correctly on GitHub
 - [ ] Add topics: claude-code, ai-memory, context-management, developer-tools
 - [ ] Add description: "Endless Auto-Recall Memory for Claude Code"

--- a/README.md
+++ b/README.md
@@ -77,6 +77,18 @@ Then:
 
 See [Setup Guide](docs/setup-guide.md) for detailed walkthrough.
 
+### Using JitNeuro with Cursor
+
+Cursor doesn't use slash commands. To get **guardrails**, **save**, **load**, and **learn** in Cursor: copy the intent rule so the agent knows what to do when it sees those intents. The agent will **read** CLAUDE.md and MEMORY.md (they change constantly) instead of using copied text.
+
+1. Install JitNeuro as above so your workspace or project has `.claude/` (commands, session-state, bundles, engrams, etc.).
+2. Copy the Cursor rule:  
+   `cp jitneuro/templates/cursor/rules/jitneuro-intents.mdc .cursor/rules/`  
+   (create `.cursor/rules/` if needed).
+3. Use the same `.claude/` layout; the rule tells the agent to read CLAUDE.md and MEMORY.md when needed.
+
+See [templates/cursor/README.md](templates/cursor/README.md) and [docs/cursor-and-cross-vendor.md](docs/cursor-and-cross-vendor.md) for details. What we ship for Cursor is defined in [docs/cursor-enablement-context.md](docs/cursor-enablement-context.md).
+
 ## File Structure
 
 ```

--- a/docs/commands-reference.md
+++ b/docs/commands-reference.md
@@ -16,9 +16,9 @@ Manage the current session. Default (no subcommand) shows current session status
   - `pulse` -- re-read shared state from other sessions
   - `switch <name|#>` -- save current + load another in one step
   - `rename <new-name>` -- rename current session
-  - `dashboard` -- current session's blockers and NEEDS DAN items
+  - `dashboard` -- current session's blockers and NEEDS OWNER items
 
-- **Tracking:** Active session stored in `.claude/session-state/.current`
+- **Tracking:** Active session resolved from `.claude/session-state/.session-id` + `.current.d/<id>` when set (per-session), else `.claude/session-state/.current` (legacy). See session.md "Resolve my current".
 - **Tag rule:** Every response ends with `[session: <name>]`
 
 Examples:

--- a/docs/commands-reference.md
+++ b/docs/commands-reference.md
@@ -36,7 +36,7 @@ Examples:
 ---
 
 ### /sessions [list|show|stale|clean|archive|delete|dashboard]
-Manage all session checkpoints. Default shows a numbered list with NEEDS DAN summary across all sessions and active work.
+Manage all session checkpoints. Default shows a numbered list with NEEDS OWNER summary across all sessions and active work.
 
 - **Subcommands:**
   - `<number>` or `show <name|#>` -- show full detail
@@ -44,13 +44,13 @@ Manage all session checkpoints. Default shows a numbered list with NEEDS DAN sum
   - `clean` -- delete stale sessions (confirms first)
   - `archive <name|#>` -- move to archive
   - `delete <name|#>` -- delete (confirms first)
-  - `dashboard` -- aggregate NEEDS DAN across all sessions
+  - `dashboard` -- aggregate NEEDS OWNER across all sessions
 
 - **Note:** Active session marked with `*` in list output
 
 Examples:
 ```
-/sessions                    -- numbered list + NEEDS DAN summary
+/sessions                    -- numbered list + NEEDS OWNER summary
 /sessions 3                  -- show detail for session #3
 /sessions archive 4          -- archive session #4
 /sessions stale              -- which sessions are >3 days old

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -2,7 +2,7 @@
 
 ## Context Bundles
 
-Self-contained knowledge files (50-80 lines max) covering one domain. Examples:
+Self-contained knowledge files (50-180 lines max) covering one domain. Examples:
 - `deploy.md` -- deployment pipeline, container commands, environments
 - `api-design.md` -- API conventions, auth patterns, error handling
 - `sprint.md` -- sprint protocol, task format, commit conventions
@@ -137,7 +137,7 @@ A typical working session adds **~1-2%** more for on-demand context.
 | Component | Limit | Why |
 |-----------|-------|-----|
 | MEMORY.md | 200 lines (hard) | Claude Code truncates beyond 200 -- content silently lost |
-| Bundles | 80 lines each | Longer bundles get skimmed or partially read |
+| Bundles | 180 lines each | Longer bundles get skimmed or partially read |
 | Engrams | 150 lines each | Diminishing returns -- trim stale content |
 | CLAUDE.md | 30-40 lines | Loaded every session -- keep minimal |
 | Session state | 30-60 lines | Checkpoint, not transcript |

--- a/docs/cursor-and-cross-vendor.md
+++ b/docs/cursor-and-cross-vendor.md
@@ -1,0 +1,167 @@
+# Cursor and Cross-Vendor Use of JitNeuro
+
+This doc answers: (1) Can Cursor leverage JitNeuro without change? (2) What changes make it cross-vendor useful?
+
+---
+
+## Summary
+
+| Layer | Cursor as-is? | Cross-vendor approach |
+|-------|----------------|------------------------|
+| **Bundles, engrams, session-state, manifest** | ✅ Yes (read/write same paths) | Use vendor-neutral dir (e.g. `.ai/`) so both read same files |
+| **Brainstem / core rules** | ⚠️ Adapt | Map CLAUDE.md → Cursor rules or AGENTS.md |
+| **Slash commands** | ❌ No | Commands become “intent docs” + one Cursor rule that routes to them |
+| **Hooks** | ❌ No | Claude-only; Cursor gets best-effort or no hooks |
+| **Config (jitneuro.json)** | ✅ Yes | Same JSON in shared location |
+
+---
+
+## 1. What Cursor Can Use Without Change
+
+- **Content under `.claude/`**  
+  Cursor can read and write the same files Claude Code uses:
+  - `context-manifest.md` (bundle index, routing)
+  - `bundles/*.md`
+  - `engrams/*.md`
+  - `session-state/*.md`
+  - `jitneuro.json`
+
+  So the *concepts* (bundles, engrams, session state, routing) work in Cursor; the agent just needs to be told where they live and when to use them.
+
+- **Workflows**  
+  “Load bundle X for this task”, “save session state”, “read manifest for routing” are all file I/O. Cursor can do that from prompts or rules; no Claude-specific API is required.
+
+- **Config**  
+  `jitneuro.json` is just JSON. Cursor (or any tool) can read it if the path is known.
+
+---
+
+## 2. What Requires Adaptation
+
+### 2.1 Slash commands
+
+- **Claude Code:** Resolves `/save`, `/load`, etc. from `~/.claude/commands/` and `<repo>/.claude/commands/` and injects the corresponding `.md` as prompt.
+- **Cursor:** No built-in “slash → load this .md as prompt.” So “commands” are not auto-invoked.
+
+**Adaptation:** Treat commands as **intent handlers**, not as Cursor slash resolution:
+
+- Keep the same command docs (e.g. `save.md`, `load.md`, `session.md`) as the single source of truth.
+- Add **one** Cursor rule that defines trigger intents and what to do (so “when you see it, you know what to do” — no slash required).
+
+**Done:** The rule is in `templates/cursor/rules/jitneuro-intents.mdc`. It is always-applied and covers:
+- **Guardrails** — override goals, never bypass, full list in CLAUDE.md
+- **Save** — trigger phrases + gather state → write `session-state/<name>.md` → sync Hub → update `.current` → confirm
+- **Load** — resolve name/# → read session file → read listed bundles + manifest → update `.current` → report
+- **Learn** — health check → scan session for learnings → proposed changes table → approve then execute
+
+Copy that file to your repo’s `.cursor/rules/` (or workspace `.cursor/rules/`). Path can be `.claude/commands/` for full details; the rule inlines the essential steps so the agent can act without opening another file.
+
+### 2.2 Hooks (PreCompact, SessionStart, PreToolUse, SessionEnd)
+
+- **Claude Code:** Hooks are wired in `settings.local.json`, run bash scripts on lifecycle events.
+- **Cursor:** No equivalent hook system (no PreCompact, SessionStart, etc.).
+
+**Adaptation:**
+
+- **Option A (pragmatic):** Document that Cursor does not support hooks. Users lose:
+  - Pre-compact save prompt
+  - Session-start recovery
+  - Branch-protection on tool use
+  - Session-end autosave  
+  Mitigation: rely on the agent following the command docs (e.g. “before you summarize or drop context, offer /save”) and on manual discipline.
+
+- **Option B (later):** Provide a Cursor extension or external watcher that approximates some of this (e.g. “on context clear, write a recovery hint file”) — larger effort, optional.
+
+So: **no code change to JitNeuro**; only documentation and, optionally, a separate Cursor-side layer.
+
+### 2.3 Brainstem (CLAUDE.md) and MEMORY.md
+
+- **Claude Code:** Loads CLAUDE.md (and MEMORY.md) automatically at session start.
+- **Cursor:** Uses `.cursor/rules/` (and optionally AGENTS.md), not CLAUDE.md/MEMORY.md.
+
+**Adaptation:**
+
+- **Brainstem:**  
+  - Either copy “brainstem” content into a Cursor rule with `alwaysApply: true` (e.g. `.cursor/rules/jitneuro-brainstem.mdc`),  
+  - Or put it in AGENTS.md and point Cursor at that file.  
+  No need to change the *content* of the brainstem; only the *injection mechanism* (Claude = CLAUDE.md, Cursor = rule or AGENTS.md).
+
+- **MEMORY.md / routing:**  
+  Treat as a referenced doc: “When deciding which bundles to load, read MEMORY.md (and context-manifest) and use the routing weights.”  
+  Add that to the same Cursor rule or to the “command router” rule so the agent always has the instruction to consult MEMORY + manifest.
+
+---
+
+## 3. Changes That Make JitNeuro Cross-Vendor Useful
+
+### 3.1 Vendor-neutral directory (recommended)
+
+- **Idea:** Keep one set of content that both Claude and Cursor read/write.
+- **Option 1 – Shared under `.claude/`:**  
+  Cursor is told (via rule/AGENTS.md): “JitNeuro context lives under `.claude/`: bundles, engrams, session-state, context-manifest, commands.”  
+  No move; only document that Cursor uses the same paths.
+
+- **Option 2 – New vendor-neutral root:**  
+  Introduce something like `.ai/` (or `ai-context/`) and move (or symlink/copy) there:
+  - `context-manifest.md`
+  - `bundles/`
+  - `engrams/`
+  - `session-state/`
+  - `commands/` (intent docs)
+  - `jitneuro.json`
+
+  Then:
+  - **Claude:** Keep using `.claude/` but have install script (or docs) copy/symlink from `.ai/` → `.claude/`, or point Claude at `.ai/` if it ever supports a configurable root.
+  - **Cursor:** One rule: “JitNeuro context lives under `.ai/`. Commands, bundles, engrams, session-state, manifest live there.”
+
+  Benefit: one canonical place; both vendors “point” at it (Claude today via .claude, Cursor via rule). Easiest long-term is “keep .claude, document it as shared” (Option 1); Option 2 is for a cleaner cross-tool story.
+
+### 3.2 Single “command router” rule for Cursor
+
+Add a Cursor rule (e.g. `.cursor/rules/jitneuro-commands.mdc`) that:
+
+1. **Path:** Assumes JitNeuro root is `.claude/` (or `.ai/` if you adopt that).
+2. **Intents:** On user intent matching a known command (`/save`, `/load`, `/session`, `/bundle`, `/learn`, “checkpoint session”, “load session X”, etc.), read the corresponding `commands/<name>.md` (or the consolidated session.md, save.md, load.md, etc.) and follow its instructions.
+3. **Manifest + MEMORY:** When loading context for a task, read `context-manifest.md` and MEMORY.md (routing weights) and load the suggested bundles.
+
+No change to the existing command markdown; they stay the single source of truth for both Claude and Cursor.
+
+### 3.3 Document “Cursor mode” in setup guide
+
+In `docs/setup-guide.md` (or a dedicated `docs/cursor.md`):
+
+- State that Cursor can use the same bundles, engrams, session-state, and manifest.
+- Explain that slash commands work via “intent + rule” (and where the rule lives).
+- State that hooks are Claude Code–only; list what Cursor users don’t get and suggest mitigations (e.g. “ask the agent to offer /save before big context changes”).
+- Optionally: one-time setup steps (e.g. “Add `.cursor/rules/jitneuro-commands.mdc` and, if desired, copy brainstem into a Cursor always-on rule”).
+
+### 3.4 Optional: install script variant for Cursor
+
+- **User-level:** Script creates or updates:
+  - `.cursor/rules/jitneuro-commands.mdc` (command router)
+  - Optionally `.cursor/rules/jitneuro-brainstem.mdc` from CLAUDE-brainstem.md
+- **Project-level:** Same rule files under `<repo>/.cursor/rules/`.
+
+No change to hook or Claude-only config; just adding Cursor rule files so “install for Cursor” is one command.
+
+---
+
+## 4. What Stays Claude-Only (No Change to JitNeuro Core)
+
+- **Hook registration** (`settings.local.json`, `jitneuro.json` hook events): only meaningful in Claude Code.
+- **Slash resolution** (loading `.md` from `commands/` when user types `/save`): Claude feature; Cursor uses the “intent + rule” approach above.
+- **MEMORY.md / CLAUDE.md auto-loading:** product-specific; Cursor uses rules/AGENTS.md to get the same content.
+
+The JitNeuro *design* (bundles, engrams, session state, manifest, command semantics) stays the same; only the *integration point* (Claude vs Cursor) differs.
+
+---
+
+## 5. Minimal Checklist for “Cursor + cross-vendor”
+
+- [ ] **Document:** Cursor can use `.claude/` (or `.ai/`) content as-is; no change to bundle/engram/session-state format.
+- [ ] **Add:** One Cursor rule (or AGENTS.md block) that routes user intents to the existing command .md files and tells the agent to use manifest + MEMORY for routing.
+- [ ] **Add:** Optional Cursor rule that injects brainstem content (from CLAUDE-brainstem.md) so Cursor has the same “always on” rules.
+- [ ] **Document:** Hooks are Claude Code–only; Cursor behavior and mitigations.
+- [ ] **Optional:** Vendor-neutral root (e.g. `.ai/`) and/or install script that writes the Cursor rule(s) so one install works for both.
+
+With that, Cursor leverages the same process (context model, commands, session state, routing) with minimal change; the only real gaps are hooks and native slash resolution, both addressed by documentation and one small rule layer.

--- a/docs/cursor-enablement-context.md
+++ b/docs/cursor-enablement-context.md
@@ -1,0 +1,84 @@
+# Cursor Enablement — Context Document
+
+This document defines what must exist and be deployed in the **jitneuro** repo so that **others can use JitNeuro from Cursor**. Use it as the source of truth for Cursor enablement: what we ship, where it lives, and what’s left to do.
+
+---
+
+## 1. Goal
+
+**Cursor enablement** means: someone who uses **Cursor** (not Claude Code) can use JitNeuro’s core behavior — **guardrails**, **save**, **load**, **learn** — without relying on slash commands or Claude-specific hooks. The agent recognizes intent (from natural language or phrases like “save session”, “load my-task”, “run learn”) and knows what to do. Guardrails, routing, and project rules always come from **reading** CLAUDE.md and MEMORY.md (live sources), never from copied or cached text.
+
+---
+
+## 2. What We Need to Deploy (Checklist)
+
+### 2.1 Artifacts that must be in the repo
+
+| Artifact | Path | Purpose |
+|----------|------|---------|
+| **Cursor rule** | `templates/cursor/rules/jitneuro-intents.mdc` | Single always-on rule: when the agent sees save/load/learn/guardrail intent, follow the defined steps. Instructs to **read** CLAUDE.md and MEMORY.md when needed. |
+| **Cursor README** | `templates/cursor/README.md` | How to install the rule (copy to `.cursor/rules/`), path resolution, dependency on existing `.claude/` layout. |
+| **Cross-vendor doc** | `docs/cursor-and-cross-vendor.md` | Explains what Cursor can use as-is, what requires adaptation, and points to the intent rule. |
+| **This context doc** | `docs/cursor-enablement-context.md` | Defines what “Cursor enablement” means and what we deploy for it. |
+
+### 2.2 Content the Cursor rule must enforce
+
+- **Guardrails:** Override goals; never bypass; get current list by **reading** project/workspace `.claude/CLAUDE.md` (and repo `CLAUDE.md`). No cached copy.
+- **Save:** Trigger phrases → determine session name → gather state → write `.claude/session-state/<name>.md` → sync Hub if present → update `.current` → confirm. If compact/preserve rules needed, **read** CLAUDE.md.
+- **Load:** Resolve session (name or #) → **read** session file → **read** listed bundles → **read** `.claude/context-manifest.md` and **MEMORY.md** (routing; always read file) → update `.current` → report.
+- **Learn:** **Read MEMORY.md** (no cache) → health check (line counts, routing, sessions, bundles, engrams) → scan conversation for learnings → proposed changes table → approve then execute.
+- **Source-of-truth principle:** At top of rule and where relevant: CLAUDE.md and MEMORY.md are live; **read** when needed, never copy into the rule or rely on stale context.
+
+### 2.3 Documentation that must reference Cursor
+
+- **Main README** (`README.md`): Add a short “Using JitNeuro with Cursor” section that links to `templates/cursor/README.md` or `docs/cursor-and-cross-vendor.md`, and states that Cursor users copy the intent rule to `.cursor/rules/` and rely on the same `.claude/` layout.
+- **Setup guide** (`docs/setup-guide.md`): Optional “Cursor users” subsection: install `.claude/` via existing install script (for shared context); then copy `templates/cursor/rules/jitneuro-intents.mdc` to `.cursor/rules/`. No hooks in Cursor; guardrails/save/load/learn work via the rule.
+
+### 2.4 Optional (not required for “others can use Cursor”)
+
+- **Install script changes:** Add a Cursor mode or flag to `install.sh` / `install.ps1` that also copies `templates/cursor/rules/jitneuro-intents.mdc` to the target’s `.cursor/rules/` (creating `.cursor/rules/` if needed). Useful for one-command Cursor setup.
+- **Verify:** A Cursor-specific verification (e.g. “does `.cursor/rules/jitneuro-intents.mdc` exist?”) could be added to a doc or a separate small script; not required for minimal enablement.
+- **Engram:** If the jitneuro engram (e.g. in the workspace `.claude/engrams/`) is used for contributor context, add a line that Cursor enablement = intent rule + read CLAUDE.md/MEMORY.md; artifacts live under `templates/cursor/` and `docs/cursor-*.md`.
+
+---
+
+## 3. Where Things Live (Summary)
+
+```
+jitneuro/
+├── templates/
+│   └── cursor/
+│       ├── README.md                    # Install + path note for Cursor
+│       └── rules/
+│           └── jitneuro-intents.mdc     # Guardrails, save, load, learn (read CLAUDE.md / MEMORY.md)
+├── docs/
+│   ├── cursor-and-cross-vendor.md       # Cursor vs Claude; intent-based behavior
+│   └── cursor-enablement-context.md      # This file — what we deploy for Cursor
+└── README.md                            # Add "Using JitNeuro with Cursor" → cursor template / cross-vendor doc
+```
+
+User’s repo or workspace after setup:
+
+- **Claude Code:** `.claude/` populated by install script (commands, hooks, bundles, session-state, etc.).
+- **Cursor:** Same `.claude/` (shared context); plus `.cursor/rules/jitneuro-intents.mdc` copied from `templates/cursor/rules/`. Agent reads CLAUDE.md and MEMORY.md from their normal locations.
+
+---
+
+## 4. Out of Scope for This Enablement
+
+- Cursor extension (hooks, PreCompact, etc.): not required for guardrails/save/load/learn; can be a later project.
+- Changing JitNeuro’s core behavior for Claude Code: Cursor enablement is additive (rule + docs), not a change to existing commands or hooks.
+- Vendor-neutral directory (e.g. `.ai/`): optional refactor; current enablement uses existing `.claude/` and only adds a Cursor rule that reads from it.
+
+---
+
+## 5. Definition of Done for “Cursor enablement deployed”
+
+- [ ] `templates/cursor/rules/jitneuro-intents.mdc` is in repo and enforces guardrails, save, load, learn with “read CLAUDE.md / MEMORY.md” (no copy).
+- [ ] `templates/cursor/README.md` describes install (copy rule to `.cursor/rules/`) and `.claude/` dependency.
+- [ ] `docs/cursor-and-cross-vendor.md` exists and points to the intent rule and install.
+- [ ] `docs/cursor-enablement-context.md` (this doc) exists and defines the deployment checklist.
+- [ ] Main `README.md` has a “Using JitNeuro with Cursor” (or similar) section linking to the Cursor template or cross-vendor doc.
+- [ ] Optional: setup guide mentions Cursor one-time step (copy rule); optional: install script can copy the Cursor rule.
+
+When all required items are true, “Cursor enablement” is deployed: others can use Cursor with JitNeuro by copying the rule and using the same `.claude/` layout, with guardrails and live rules coming from reading CLAUDE.md and MEMORY.md.

--- a/docs/hooks-guide.md
+++ b/docs/hooks-guide.md
@@ -2,7 +2,7 @@
 
 ## Why Hooks Matter
 
-Hooks automate what you'd otherwise forget. They fire on Claude Code lifecycle events -- before compaction, before dangerous git commands, when sessions end. JitNeuro ships 4 hooks that protect your work and enforce governance automatically.
+Hooks automate what you'd otherwise forget. They fire on Claude Code lifecycle events -- before compaction, before dangerous git commands, when sessions end. JitNeuro ships 5 hooks that protect your work and enforce governance automatically.
 
 Hooks are the safety net that ensures context is never silently lost. When compaction fires, your session state is preserved. When you accidentally try to push to a protected branch, the hook catches it. They run automatically on Claude Code lifecycle events with no manual intervention required.
 
@@ -25,7 +25,17 @@ Prompts Claude to offer `/save` before context gets compressed. Claude will ask 
 
 **Why this matters:** Context compaction is the #1 cause of lost work. After compaction, Claude forgets active tasks, loaded bundles, file positions, and next steps. This hook catches it before it happens.
 
-### 2. Post-Compact Context Recovery
+### 2. Session Start — Write Session ID (per-session .current)
+
+- **Event:** SessionStart (matcher: `""` — all session starts)
+- **Script:** session-start-write-id.sh
+- **Timeout:** 5s
+
+Parses `session_id` from the hook JSON and writes it to `.claude/session-state/.session-id`. Commands then resolve "my current" from `.current.d/<id>` so multiple conversations can each have their own active session. No stdout; exit 0.
+
+**Why this matters:** Without this, only one conversation per workspace could have a "current" session; the single `.current` file was shared. With it, each Claude Code (or Cursor) chat can track its own current session.
+
+### 3. Post-Compact Context Recovery
 
 - **Event:** SessionStart (matcher: `compact`)
 - **Script:** session-start-recovery.sh
@@ -37,7 +47,7 @@ stdout from this hook goes directly into Claude's context -- no user action need
 
 **Why this matters:** After compaction, Claude forgets what it was doing. This hook restores the last checkpoint automatically so you can pick up where you left off without manually re-explaining context.
 
-### 3. Branch Protection
+### 4. Branch Protection
 
 - **Event:** PreToolUse (matcher: `Bash`)
 - **Script:** branch-protection.sh
@@ -58,7 +68,7 @@ When a command is blocked, Claude receives the reason via stderr and will inform
 
 **Why this matters:** Governance rules written in CLAUDE.md are "prose rules" -- Claude follows them most of the time, but can still slip. This hook enforces RED zone protections programmatically. The dangerous command never executes.
 
-### 4. Session End Auto-Save
+### 5. Session End Auto-Save
 
 - **Event:** SessionEnd
 - **Script:** session-end-autosave.sh

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -144,7 +144,7 @@ Copy `templates/bundles/example.md` and fill in your domain:
 cp templates/bundles/example.md .claude/bundles/deploy.md
 ```
 
-Edit with your actual deployment context. Keep under 80 lines.
+Edit with your actual deployment context. Keep under 180 lines.
 Include: key files, commands, conventions, gotchas.
 Exclude: anything Claude can infer from reading the code.
 
@@ -234,7 +234,7 @@ See [concepts.md](concepts.md) for detailed explanation with examples.
 | Hooks not firing | Run `/verify` to check hooks config and script paths. |
 | "bash not found" on Windows | Install Git for Windows. Installer detects paths automatically. |
 | settings.local.json parse error | Installer skips merge on parse failure. Fix JSON and re-run. |
-| Claude ignores bundle content | Bundle too long (over 80 lines) or conflicting with CLAUDE.md. |
+| Claude ignores bundle content | Bundle too long (over 180 lines) or conflicting with CLAUDE.md. |
 | Wrong bundles loaded | Update routing weights in manifest/MEMORY.md. |
 | Context still fills up | Use agents more aggressively, save/clear more often. |
 | /load loads stale state | Check session date with `/sessions`. |

--- a/install.ps1
+++ b/install.ps1
@@ -73,7 +73,7 @@ if ($PrevVersion) {
 Write-Host ""
 
 # Create directories
-$dirs = @("commands", "bundles", "engrams", "session-state", "rules", "hooks")
+$dirs = @("commands", "bundles", "engrams", "session-state", "session-state\.current.d", "rules", "hooks")
 foreach ($dir in $dirs) {
     $path = Join-Path $Target $dir
     if (-not (Test-Path $path)) {
@@ -242,6 +242,12 @@ $hooksConfig = @{
             }
         )
         SessionStart = @(
+            @{
+                matcher = ""
+                hooks = @(
+                    @{ type = "command"; command = "$BashPathFwd `"$HooksPathFwd/session-start-write-id.sh`""; timeout = 5 }
+                )
+            }
             @{
                 matcher = "compact"
                 hooks = @(

--- a/install.sh
+++ b/install.sh
@@ -80,6 +80,7 @@ mkdir -p "$TARGET/commands"
 mkdir -p "$TARGET/bundles"
 mkdir -p "$TARGET/engrams"
 mkdir -p "$TARGET/session-state"
+mkdir -p "$TARGET/session-state/.current.d"
 mkdir -p "$TARGET/rules"
 mkdir -p "$TARGET/hooks"
 
@@ -187,7 +188,10 @@ build_hooks_json() {
 {
   "hooks": {
     "PreCompact": [{ "matcher": "", "hooks": [{ "type": "command", "command": "bash \"${HOOKS_PATH_FWD}/pre-compact-save.sh\"", "timeout": 10 }] }],
-    "SessionStart": [{ "matcher": "compact", "hooks": [{ "type": "command", "command": "bash \"${HOOKS_PATH_FWD}/session-start-recovery.sh\"", "timeout": 10 }] }],
+    "SessionStart": [
+    { "matcher": "", "hooks": [{ "type": "command", "command": "bash \"${HOOKS_PATH_FWD}/session-start-write-id.sh\"", "timeout": 5 }] },
+    { "matcher": "compact", "hooks": [{ "type": "command", "command": "bash \"${HOOKS_PATH_FWD}/session-start-recovery.sh\"", "timeout": 10 }] }
+  ],
     "PreToolUse": [{ "matcher": "Bash", "hooks": [{ "type": "command", "command": "bash \"${HOOKS_PATH_FWD}/branch-protection.sh\"", "timeout": 5 }] }],
     "SessionEnd": [{ "matcher": "", "hooks": [{ "type": "command", "command": "bash \"${HOOKS_PATH_FWD}/session-end-autosave.sh\"", "timeout": 10 }] }]
   }

--- a/templates/bundles/example.md
+++ b/templates/bundles/example.md
@@ -5,7 +5,7 @@
 
   A bundle is a self-contained context file for one domain.
   Guidelines:
-  - Keep under 80 lines (ideally 40-60)
+  - Keep under 180 lines (ideally 40-60)
   - Include everything Claude needs for this domain
   - No dependencies on other bundles (self-contained)
   - Use tables and lists for density

--- a/templates/commands/bundle.md
+++ b/templates/commands/bundle.md
@@ -39,7 +39,7 @@ a. **Look for context to build from.** Search the workspace for a repo, director
 
 b. **If source material found:** Analyze it (package.json, README, CLAUDE.md,
    key files, recent commits, engram) and draft a bundle. A good bundle is
-   50-80 lines covering:
+   50-180 lines covering:
    - Identity (what is this, one line)
    - Architecture (how it's structured, key patterns)
    - Key Files (table: path, purpose -- most important files only)
@@ -68,7 +68,7 @@ Bundles:
 | Bundle | Lines | Status | Description |
 |--------|-------|--------|-------------|
 | active-work | 42 | OK | Current sprints, blockers |
-| blog-content | 61 | WARN | Approaching 80-line limit |
+| blog-content | 61 | WARN | Approaching 180-line limit |
 | deploy | -- | MISSING | In manifest but no file |
 | new-thing | 35 | UNLISTED | File exists, not in manifest |
 
@@ -91,7 +91,7 @@ If the user says "refresh", "update", or "rebuild" in the context of a bundle
 
 ## Splitting a Bundle
 
-If a bundle is over 80 lines, or the user asks to split:
+If a bundle is over 180 lines, or the user asks to split:
 
 1. Identify natural subdomain boundaries in the content
 2. Propose split: `<name>-a.md` and `<name>-b.md` with clear names
@@ -101,7 +101,7 @@ If a bundle is over 80 lines, or the user asks to split:
 
 ## Important
 - Always ask before writing or modifying bundle files.
-- Keep bundles under 80 lines. Over 80 means Claude may skip content.
+- Keep bundles under 180 lines. Over 80 means Claude may skip content.
 - One bundle = one domain. If a bundle covers two unrelated things, split it.
 - After any write, update context-manifest.md to match reality.
 - Routing weights live in MEMORY.md -- suggest entries but let the user approve.

--- a/templates/commands/dashboard.md
+++ b/templates/commands/dashboard.md
@@ -8,7 +8,7 @@ When invoked as `/dashboard`:
 
 1. Read `.claude/session-state/.preferences` for `shortcut_scope` setting
    - If `session` (default): execute `/session dashboard` (current session blockers)
-   - If `sessions`: execute `/sessions dashboard` (all sessions aggregate NEEDS DAN)
+   - If `sessions`: execute `/sessions dashboard` (all sessions aggregate NEEDS OWNER)
 2. Follow all instructions in the target command
 
 This is a convenience shortcut. All logic lives in `/session dashboard` or `/sessions dashboard`.

--- a/templates/commands/health.md
+++ b/templates/commands/health.md
@@ -80,7 +80,7 @@ Use these remediation patterns:
 | MEMORY.md over 170 | Extract largest section to bundle, replace with pointer |
 | MEMORY.md over 200 | CRITICAL. Identify truncated content, move immediately |
 | MEMORY.md duplicates | Keep in more-specific file, replace with pointer |
-| Bundle over 80 | Split by subdomain, update routing weights |
+| Bundle over 180 | Split by subdomain, update routing weights |
 | Bundle missing (referenced) | Create from template, populate with known context |
 | Bundle no routing entry | Add routing entry to MEMORY.md |
 | Engram over 150 | Trim History (keep 3-5 entries), compress verbose sections |

--- a/templates/commands/learn.md
+++ b/templates/commands/learn.md
@@ -23,7 +23,7 @@ Did Claude load the wrong bundle? Did the user have to manually specify context?
 Is any bundle stale, missing information, or too large?
 - New convention established this session -> add to relevant bundle
 - Bundle was loaded but didn't have what Claude needed -> update content
-- Bundle over 80 lines -> suggest split
+- Bundle over 180 lines -> suggest split
 
 ### 3. Engram Updates (.claude/engrams/)
 Did the session reveal new facts about a project's identity or architecture?
@@ -68,8 +68,8 @@ Read these files and measure actual line counts:
 
 **Bundles** (.claude/bundles/)
 - List all bundles. Count lines in each.
-- WARN at 70+ lines (approaching 80-line max)
-- Flag any bundle over 80 lines -> suggest split
+- WARN at 150+ lines (approaching 180-line max)
+- Flag any bundle over 180 lines -> suggest split
 - Flag bundles not loaded in current session that routing weights say should have been
 - Check for bundles referenced in routing weights that don't exist
 
@@ -97,7 +97,7 @@ Memory System Health:
 | Component | Status | Detail |
 |-----------|--------|--------|
 | MEMORY.md | OK (89/200 lines) | |
-| Bundles | WARN | blog.md at 74/80 lines |
+| Bundles | WARN | blog.md at 155/180 lines |
 | Engrams | OK (3 files, all under 150) | |
 | Sessions | WARN | 2 stale (>3 days) |
 | Routing | MISS | No route for "stripe" tasks |
@@ -125,8 +125,8 @@ Memory System Health:
 | MEMORY.md over 200 lines | CRITICAL. Identify what's being truncated (lines 201+). Move truncated content to appropriate file immediately. Then apply 170+ fix to create headroom. |
 | MEMORY.md has duplicates | Keep the canonical copy in the more specific file (bundle > MEMORY.md). Replace duplicate in MEMORY.md with pointer. |
 | MEMORY.md has stale entries | Verify with user before removing. Mark as "UNVERIFIED" if unsure, delete if confirmed stale. |
-| Bundle over 80 lines | Split by subdomain. Example: `deploy.md` -> `deploy-pipeline.md` + `deploy-environments.md`. Update routing weights to reference both. |
-| Bundle missing content | Add the missing information. If it pushes over 80 lines, split first. |
+| Bundle over 180 lines | Split by subdomain. Example: `deploy.md` -> `deploy-pipeline.md` + `deploy-environments.md`. Update routing weights to reference both. |
+| Bundle missing content | Add the missing information. If it pushes over 180 lines, split first. |
 | Bundle referenced but missing | Create from `templates/bundles/example.md`. Populate with known context from session. |
 | Engram over 150 lines | Trim History section (keep last 3-5 entries). Move Gotchas to a bundle if they're domain-general. Compress verbose sections. |
 | Engram missing for active project | Create from `templates/engrams/example.md`. Populate with: tech stack, key files, architecture, integrations discovered this session. |
@@ -178,7 +178,7 @@ Proposed Updates:
 - NEVER write without user approval. Present the table first.
 - Health check runs EVERY time, even if session had no learnings.
 - MEMORY.md hard limit: 200 lines. Lines beyond 200 are silently truncated by Claude Code.
-- Bundle hard limit: 80 lines. Longer bundles get ignored or partially read.
+- Bundle hard limit: 180 lines. Longer bundles get ignored or partially read.
 - Engram soft limit: 150 lines. Longer engrams waste context on low-value detail.
 - Session state soft limit: 10 active files. More than that is clutter.
 - This command reads and proposes. It does not modify code files, only memory/context files.

--- a/templates/commands/onboard.md
+++ b/templates/commands/onboard.md
@@ -84,7 +84,7 @@ Only generate files that are missing or that the user asked to refresh.
 Use the JitNeuro `templates/CLAUDE-brainstem.md` as the template.
 Fill in project-specific values.
 
-**Engram** (`.claude/engrams/[repo-name]-context.md`, ~50-80 lines):
+**Engram** (`.claude/engrams/[repo-name]-context.md`, ~50-180 lines):
 Use the JitNeuro `templates/engrams/example.md` as the template.
 Populate with discovered tech stack, key files, architecture, integrations.
 

--- a/templates/commands/session.md
+++ b/templates/commands/session.md
@@ -18,13 +18,29 @@ Numbers reference the last `/sessions` list output.
 
 ## Current Session Tracking
 
-The active session name is stored in `.claude/session-state/.current` (one line, just the name).
+**Per-session (Claude Code):** When `.claude/session-state/.session-id` exists and is non-empty, the active session name for *this* conversation is stored in `.claude/session-state/.current.d/<session_id>` (one line). This allows multiple Claude Code (or Cursor) conversations to each have their own "current" session.
+**Legacy / fallback:** The active session name is also stored in `.claude/session-state/.current` (one line). When `.session-id` is missing (e.g. Cursor, or no hook), use `.current` only.
+
+**Resolve "my current" (get active session name):**
+1. Read `.claude/session-state/.session-id`. If it exists and is non-empty, call that value `<id>`.
+2. If `<id>` is set: read `.claude/session-state/.current.d/<id>`. If that file exists, its content (one line) is the active session name. Else fall back to step 3.
+3. Else (no .session-id or empty): read `.claude/session-state/.current`. Its content (one line) is the active session name.
+4. If no file or empty: no active session.
+
+**Write "my current" (set active session name to `<name>):**
+1. Write `<name>` (one line) to `.claude/session-state/.current` (legacy + default).
+2. Read `.claude/session-state/.session-id`. If it exists and is non-empty, call that value `<id>`. Write `<name>` (one line) to `.claude/session-state/.current.d/<id>`. Create `.current.d` if needed.
+
+**Clear "my current" (e.g. active session was deleted/archived):**
+1. Read `.session-id`. If set, remove `.current.d/<id>` if it exists.
+2. If the deleted/archived session was the one in `.current`, clear `.current` (empty file or remove).
+
 Updated by: `new`, `save`, `load`, `switch`, `rename`.
 Read by: default view, `pulse`, `dashboard`, and the session tag rule.
 
 ## Session Tag Rule
 
-**Every response must end with `[session: <name>]`** where `<name>` comes from `.current`.
+**Every response must end with `[session: <name>]`** where `<name>` comes from **resolving "my current"** (see above).
 If no active session: `[session: none]`.
 This is non-negotiable -- it prevents context confusion across terminals.
 
@@ -40,7 +56,7 @@ If `.preferences` doesn't exist, default to `session` scope.
 
 ### session (default) -- current session status
 
-1. Read `.claude/session-state/.current` to get active session name
+1. **Resolve "my current"** (see Current Session Tracking) to get active session name.
 2. If no active session: "No active session. Run `/session new <name>` to start one."
 3. Read the session state file `.claude/session-state/<name>.md`
 4. Read `.claude/bundles/active-work.md` for sprint context
@@ -72,7 +88,7 @@ BLOCKED: [count] items needing attention
 
 ### session new <name>
 
-1. Check `.current` for active session
+1. **Resolve "my current"** to see if there is an active session.
 2. If active session exists:
    - Read the session state file, check age of last checkpoint
    - Check if session has unsaved state (files modified, decisions made)
@@ -98,14 +114,14 @@ BLOCKED: [count] items needing attention
    ## Next Steps
    - Awaiting direction
    ```
-4. Write session name to `.current`
+4. **Write "my current"** (session name).
 5. Confirm: "Session '<name>' created."
 
 ### session save <name>
 
 1. **Determine session name:**
    - If name provided, use it (lowercase, hyphens, task-descriptive)
-   - If no name: read `.current`. If active session, use that name.
+   - If no name: **resolve "my current"**. If active session, use that name.
    - If no name and no active session: suggest one based on current work, ASK to confirm
    - **Multiple tasks:** If session touched more than one distinct task,
      ask: "This session touched [task A] and [task B]. Save as one or separate?"
@@ -150,9 +166,17 @@ BLOCKED: [count] items needing attention
    - [discoveries worth preserving across /clear]
    ```
 
-4. Write session name to `.current`
-5. Confirm: "Saved '<name>'. Safe to /clear. Use `/session load <name>` to reload."
-6. Suggest: "Run `/learn` first if this session had learnings worth persisting."
+4. **Sync TodoWrite to Hub.md:**
+   - For each repo involved in this session, check if `<repo>/.HUB/Hub-*.md` exists
+   - If it does, compare current TodoWrite items against the "ACTIVE TODO" section
+   - Add any new TodoWrite items not yet in Hub.md
+   - Update status of completed/changed items
+   - If no Hub file exists and there are TodoWrite items, create one
+   - This is the DURABLE COPY -- TodoWrite is volatile and lost on context reset
+
+5. **Write "my current"** (session name).
+6. Confirm: "Saved '<name>'. Safe to /clear. Use `/session load <name>` to reload."
+7. Suggest: "Run `/learn` first if this session had learnings worth persisting."
 
 **Size guidance:** Target 30-60 lines. Under 30 probably missing something. Over 80 too verbose.
 
@@ -160,8 +184,8 @@ BLOCKED: [count] items needing attention
 
 1. **Determine which session:**
    - If name/number provided: resolve to session file
-   - If no name: read `.current`. If exists, load that.
-   - If no name and no `.current`: list sessions, ask user to pick
+   - If no name: **resolve "my current"**. If exists, load that.
+   - If no name and no current: list sessions, ask user to pick
    - If number: resolve from last `/sessions` list output
 
 2. **Read the session state file**
@@ -170,7 +194,7 @@ BLOCKED: [count] items needing attention
 
 4. **Read `.claude/context-manifest.md`** for bundle awareness
 
-5. **Write session name to `.current`**
+5. **Write "my current"** (session name).
 
 6. **Report:**
    ```
@@ -186,7 +210,7 @@ BLOCKED: [count] items needing attention
 
 ### session pulse
 
-1. Read `.current` to identify active session
+1. **Resolve "my current"** to identify active session.
 2. Read shared state files in parallel:
    - `.claude/bundles/active-work.md`
    - All `.claude/session-state/*.md` (exclude archive/, _autosave.md)
@@ -211,20 +235,20 @@ BLOCKED: [count] items needing attention
 1. Run `session save` flow for current session (auto-save, no name prompt needed)
 2. Prompt: "Learnings worth persisting before switching? (yes -> /learn / no -> switch now)"
 3. Run `session load` flow for target session
-4. Update `.current` to new session name
+4. **Write "my current"** (new session name).
 
 ### session rename <new-name>
 
-1. Read `.current` to get active session name
+1. **Resolve "my current"** to get active session name.
 2. If no active session: "No active session to rename."
 3. Rename `.claude/session-state/<old-name>.md` to `<new-name>.md`
-4. Update `.current` to new name
+4. **Write "my current"** (new name).
 5. Update the `# Session:` header inside the file
 6. Confirm: "Renamed '<old>' -> '<new>'."
 
 ### session dashboard
 
-1. Read `.current` to get active session
+1. **Resolve "my current"** to get active session.
 2. Read the session state file
 3. Read `.claude/bundles/active-work.md`
 4. Read Hub.md files for repos in this session only
@@ -252,5 +276,5 @@ BLOCKED: [count] items needing attention
 - Do NOT modify code files from any session subcommand
 - Session names are cross-repo by design
 - If session file already exists on save, UPDATE it (preserve previous context)
-- `.current` is the single source of truth for active session
+- Use **resolve "my current"** / **write "my current"** (per-session when .session-id exists; else .current).
 - Always end every response with `[session: <name>]`

--- a/templates/commands/session.md
+++ b/templates/commands/session.md
@@ -12,7 +12,7 @@ Trigger on these patterns (case-insensitive):
 - `session pulse` -- re-read shared state from other sessions (shortcut: `/pulse`)
 - `session switch <name|#>` -- save current + load another in one step
 - `session rename <new-name>` -- rename current session
-- `session dashboard` -- current session blockers and NEEDS DAN items
+- `session dashboard` -- current session blockers and NEEDS OWNER items
 
 Numbers reference the last `/sessions` list output.
 

--- a/templates/commands/sessions.md
+++ b/templates/commands/sessions.md
@@ -5,7 +5,7 @@ List, inspect, and manage all session checkpoints. Numbered output for quick sel
 ## Commands
 
 Trigger on these patterns (case-insensitive):
-- `sessions` or `sessions list` -- numbered list of all sessions + NEEDS DAN summary (alias: `dashboard`)
+- `sessions` or `sessions list` -- numbered list of all sessions + NEEDS OWNER summary (alias: `dashboard`)
 - `sessions <number>` -- show full detail of session at that number
 - `sessions show <name|number>` -- show full detail
 - `sessions stale` -- list sessions >3 days old
@@ -42,12 +42,12 @@ Sessions (5 active):                              [* = current]
   5  mobile-onboarding             5d     Sprint-Mobile-001 spec            mobile-app
 ```
 
-7. Read `.claude/bundles/active-work.md` for NEEDS DAN / BLOCKED items
+7. Read `.claude/bundles/active-work.md` for NEEDS OWNER / BLOCKED items
 8. Scan Hub.md files across active repos for additional blocked items
 9. Append aggregate summary:
 
 ```
-NEEDS DAN:
+NEEDS OWNER:
   - [BLOCKED] Sprint-Auth-Refactor: push to main approval needed
   - [APPROVAL] Sprint-Checkout-001: plan review
   - [DECISION] Blog platform: Ghost vs custom
@@ -57,7 +57,7 @@ Pick a number to show details, or: sessions archive|delete <#>
 
 10. If stale sessions exist (>3 days), note:
     "2 sessions are stale (>3 days). Run `sessions stale` to review."
-11. If no NEEDS DAN items: omit that section
+11. If no NEEDS OWNER items: omit that section
 12. MANDATORY -- end the response with a plain text prompt. Do NOT use AskUserQuestion. Just print this line at the very end:
 
 ```

--- a/templates/commands/sessions.md
+++ b/templates/commands/sessions.md
@@ -29,7 +29,7 @@ Anywhere a `<name>` is accepted, a `<number>` from the last list works too.
    - Current Task line
    - Repos Involved
 4. Assign sequential numbers starting at 1
-5. Mark the active session (from `.current`) with `*`
+5. **Resolve "my current"** (see session.md — uses .session-id + .current.d/<id> or .current). Mark that session with `*` in the table (current for this conversation).
 6. Display as numbered table:
 
 ```
@@ -84,14 +84,14 @@ The user's next message will be a number or command. Never skip this prompt.
 2. Show each number, name, and task
 3. Ask confirmation: "Delete these N stale sessions? (yes/no)"
 4. On yes, delete the files
-5. If active session (`.current`) is being deleted, clear `.current`
+5. If the deleted session was **"my current"** (resolve "my current" from session.md), **clear "my current"** (remove .current.d/<id> if used; clear .current if that session was the one in .current).
 6. Report what was deleted
 
 ### sessions archive <name|number>
 
 1. Create `.claude/session-state/archive/` if needed
 2. Move `<name>.md` to `archive/<name>.md`
-3. If archived session was active (`.current`), clear `.current`
+3. If archived session was **"my current"**, **clear "my current"** (see session.md).
 4. Confirm: "Archived <name>. Still readable at session-state/archive/<name>.md"
 
 ### sessions delete <name|number>
@@ -99,7 +99,7 @@ The user's next message will be a number or command. Never skip this prompt.
 1. Read the session file, show task and last checkpoint date
 2. Ask confirmation: "Delete session '<name>'? (yes/no)"
 3. On yes, delete the file
-4. If deleted session was active (`.current`), clear `.current`
+4. If deleted session was **"my current"**, **clear "my current"** (see session.md).
 5. Confirm: "Deleted <name>."
 
 ## Important

--- a/templates/commands/status.md
+++ b/templates/commands/status.md
@@ -8,7 +8,7 @@ When invoked as `/status`:
 
 1. Read `.claude/session-state/.preferences` for `shortcut_scope` setting
    - If `session` (default): execute `/session` (current session status)
-   - If `sessions`: execute `/sessions` (all sessions list + NEEDS DAN)
+   - If `sessions`: execute `/sessions` (all sessions list + NEEDS OWNER)
 2. Follow all instructions in the target command
 
 This is a convenience shortcut. All logic lives in `/session` or `/sessions`.

--- a/templates/commands/verify.md
+++ b/templates/commands/verify.md
@@ -18,7 +18,7 @@ When invoked as `/verify`:
    |---|-----------|-------|-------|--------|-----|
    | 1 | Install version | Read version from .claude/jitneuro.json | Version found | Pre-versioned install (no jitneuro.json) | Not installed |
    | 2 | Commands | Scan .claude/commands/*.md | All 15 commands present | Some commands missing | commands/ dir missing |
-   | 3 | Hook scripts | Check .claude/hooks/*.sh exist | All 4 scripts present | Some missing | hooks/ dir missing |
+   | 3 | Hook scripts | Check .claude/hooks/*.sh exist | All 5 scripts present | Some missing | hooks/ dir missing |
    | 4 | Hooks config | Read settings.local.json, verify hooks section | All 4 hook events configured | Some events missing | No hooks config |
    | 5 | Hook paths | Each hook command path in settings.local.json points to existing file | All paths valid | -- | Script file not found |
    | 6 | Hook events | Event names match Claude Code events (PreCompact, SessionStart, PreToolUse, SessionEnd) | All valid | Unknown event name | -- |
@@ -43,8 +43,8 @@ When invoked as `/verify`:
 
    [1] Install version    GREEN  v0.1.2
    [2] Commands            GREEN  15/15 installed
-   [3] Hook scripts        GREEN  4/4 present
-   [4] Hooks config        GREEN  4/4 events configured
+[3] Hook scripts        GREEN  5/5 present
+[4] Hooks config        GREEN  4 event types configured (SessionStart has 2 hooks)
    [5] Hook paths          GREEN  All paths valid
    [6] Hook events         GREEN  All event names valid
    [7] Bundles             GREEN  3 bundles
@@ -73,5 +73,5 @@ When invoked as `/verify`:
 ## Important
 - Use relative paths in output (not full system paths with username)
 - This command is READ-ONLY -- never modify files
-- If settings.local.json has extra hooks beyond JitNeuro's 4, that's fine -- only check for JitNeuro's hooks
+- If settings.local.json has extra hooks beyond JitNeuro's 5 scripts (4 event types), that's fine -- only check for JitNeuro's hooks
 - Do not fail on extras, only on missing components

--- a/templates/context-manifest.md
+++ b/templates/context-manifest.md
@@ -15,7 +15,7 @@ These load automatically at session start via CLAUDE.md:
 |--------|------|--------|-------|-----------|
 | example | .claude/bundles/example.md | Example template | ~30 | never |
 
-<!-- Add your bundles here. Keep under 80 lines each. -->
+<!-- Add your bundles here. Keep under 180 lines each. -->
 <!-- Example entries:
 | deploy    | .claude/bundles/deploy.md    | CI/CD, containers, environments | ~60 | 2026-03-09 |
 | api       | .claude/bundles/api.md       | API design, auth, error handling | ~50 | 2026-03-09 |

--- a/templates/cursor/README.md
+++ b/templates/cursor/README.md
@@ -1,0 +1,33 @@
+# Cursor rules for JitNeuro
+
+Cursor doesn’t use slash commands. The agent needs to recognize **intents** (save, load, learn, guardrails) and know what to do.
+
+## What’s here
+
+- **`rules/jitneuro-intents.mdc`** — Single always-on rule that defines:
+  - **Guardrails** — override goals; never bypass; full list in CLAUDE.md
+  - **Save** — when user wants to checkpoint: gather state, write session-state, sync Hub, confirm
+  - **Load** — when user wants to restore: resolve session, read state + bundles, report
+  - **Learn** — when user wants to persist learnings: health check, propose updates, approve then execute
+
+No slash required. When the agent sees the intent (or phrases like “save session”, “load my-task”, “run learn”), it follows the steps in the rule.
+
+## Install
+
+Copy the rule into your project or workspace so Cursor loads it:
+
+```bash
+# From repo root (project-level)
+mkdir -p .cursor/rules
+cp jitneuro/templates/cursor/rules/jitneuro-intents.mdc .cursor/rules/
+
+# Or workspace-level (e.g. D:\Code)
+mkdir -p .cursor/rules
+cp jitneuro/templates/cursor/rules/jitneuro-intents.mdc .cursor/rules/
+```
+
+Ensure your `.claude/` (or workspace `.claude/`) has the usual layout: `session-state/`, `bundles/`, `engrams/`, `context-manifest.md`. The rule references those paths.
+
+## Paths
+
+The rule uses `.claude/` for session-state, bundles, engrams, and manifest. Resolve it from the workspace root or the project root that actually contains `.claude/` (e.g. in a multi-root workspace, the root that has `session-state/`).

--- a/templates/cursor/rules/jitneuro-intents.mdc
+++ b/templates/cursor/rules/jitneuro-intents.mdc
@@ -1,0 +1,126 @@
+---
+description: JitNeuro intents — guardrails, save, load, learn. When you see these, do this.
+globs:
+alwaysApply: true
+---
+
+# JitNeuro: When You See It, Do This
+
+This rule defines **guardrails** and three core intents: **save**, **load**, **learn**. No slash required — when the user (or context) implies one of these, do the following.
+
+## Source of truth — read, never copy
+
+**CLAUDE.md** and **MEMORY.md** (and project/workspace `.claude/CLAUDE.md`) are updated constantly. You must **read** them when you need guardrails, routing weights, compact instructions, or other live rules. Do **not** rely on copied or inlined text from these files; always read the current file so you see the latest content.
+
+---
+
+## Guardrails
+
+- **Guardrails override goals.** If a task conflicts with a guardrail, the guardrail wins. Never bypass a guardrail to complete a task. Surface the conflict and ask the project owner.
+- **Get the current list by reading:** Project or workspace **`.claude/CLAUDE.md`** (and repo root `CLAUDE.md` if present). **Read that file** whenever you need the full guardrail list — trust zones, branch rules, approval workflow, critical rules. Do not use a cached or copied version; the file changes constantly.
+- **If unsure:** Treat as a guardrail. Ask before doing anything destructive or that crosses a stated boundary.
+
+---
+
+## Save (checkpoint session)
+
+**Trigger phrases (or equivalent intent):** save, checkpoint, session save, /save, “save this session”, “save session as …”, “remember where we are”.
+
+**What to do:**
+
+1. **Session name**  
+   If the user gave a name, use it (lowercase, hyphens). Otherwise read `.claude/session-state/.current`; if there’s an active session, use that name. If none, suggest a short task-based name and confirm.
+
+2. **Gather state**  
+   From current context: current task, repos involved, active bundles, modified files, key decisions, pending/unresolved items, next steps, key findings. If you need what to preserve on compact or project rules, **read CLAUDE.md** (and `.claude/CLAUDE.md` if in scope) — do not rely on a copy; those files change constantly.
+
+3. **Write**  
+   Write to `.claude/session-state/<name>.md` in this format:
+   - `# Session: <name>`
+   - `**Checkpointed:**` date/time
+   - `## Current Task` — task and status
+   - `## Repos Involved` — list with brief note
+   - `## Active Bundles` — which bundles are loaded and why
+   - `## Modified Files` — paths and what changed
+   - `## Key Decisions` — decisions and reasoning
+   - `## Pending / Unresolved` — items needing input
+   - `## Next Steps` — ordered list
+   - `## Key Findings` — discoveries worth keeping across context reset  
+   Target 30–60 lines.
+
+4. **Sync todos**  
+   If the session involves repos with `.HUB/Hub-*.md`, align current TodoWrite-style items with the “ACTIVE TODO” section (add new, update status). If there are todos and no Hub file, consider creating one.
+
+5. **Update current**  
+   Write the session name to `.claude/session-state/.current`. If `.session-id` exists and is non-empty, also write to `.claude/session-state/.current.d/<id>` (create `.current.d` if needed).
+
+6. **Confirm**  
+   Say something like: “Saved `<name>`. Safe to clear context. Use load to restore.” If the session had learnings, suggest running **learn** next.
+
+**Current (per-session):** To get "my" active session name: read `.claude/session-state/.session-id`; if non-empty, read `.claude/session-state/.current.d/<id>` (content = session name); else read `.claude/session-state/.current`. To **update current** after save: write session name to `.current`; if `.session-id` exists, also write session name to `.current.d/<id>` (create `.current.d` if needed).
+
+**Paths:** Resolve `.claude/` from workspace root or project root (whichever holds `session-state/`).
+
+---
+
+## Load (restore session)
+
+**Trigger phrases (or equivalent intent):** load, restore, session load, /load, “load session …”, “restore …”, “pick up where we left off”, “switch to session …”.
+
+**What to do:**
+
+1. **Which session**  
+   If the user gave a name or number, use it. If not, resolve "my current" (`.session-id` → `.current.d/<id>` or `.current`) and load that session if it exists. If no name and no current, list sessions (excluding `archive/`, `_autosave.md`, `.current`, `.current.d/`, `.session-id`, `.preferences`) and ask which to load. A number refers to the Nth session in that list.
+
+2. **Read**  
+   Read the session file `.claude/session-state/<name>.md`.
+
+3. **Load bundles**  
+   For each bundle listed under “Active Bundles” in that file, read the corresponding `.claude/bundles/<name>.md`.
+
+4. **Read manifest and memory**  
+   Read `.claude/context-manifest.md` for bundle index. Read **MEMORY.md** for current routing weights and project index (it changes constantly — always read the file).
+
+5. **Update current**  
+   Write the session name to `.claude/session-state/.current`. If `.session-id` exists and is non-empty, also write the session name to `.claude/session-state/.current.d/<id>` (create `.current.d` if needed).
+
+6. **Report**  
+   Summarize: “Loaded: &lt;name&gt; (checkpointed &lt;date&gt;). Task: … Repos: … Loaded bundles: … Next steps: 1. …”  
+   If the checkpoint is older than 3 days, note that it may be stale and ask if it’s still relevant.
+
+**Paths:** Same as save — workspace or project `.claude/`.
+
+---
+
+## Learn (persist learnings + memory health)
+
+**Trigger phrases (or equivalent intent):** learn, /learn, “persist this”, “update memory”, “remember this”, “run learn”, “memory health”.
+
+**What to do:**
+
+1. **Memory health check**  
+   **Read MEMORY.md** (do not use a cached copy — it changes constantly). Then:  
+   - Count lines. Warn at 150+, critical at 190+ (hard limit 200). Note truncation/stale/duplicates.  
+   - **Bundles** (`.claude/bundles/`): List, count lines each. Warn at 150+ (max 180). Note missing or oversized.  
+   - **Engrams** (`.claude/engrams/`): List, count lines each. Warn at 130+ (soft max 150). Note missing for active projects.  
+   - **Session state** (`.claude/session-state/`): List files and age. Flag >3 days stale, >7 days for archive/delete.  
+   - **Routing:** From the MEMORY.md you just read, check routing weights; note missing routes or references to missing bundles/engrams.  
+   Present a short table: Component | Status | Detail | Fix.
+
+2. **Scan session for learnings**  
+   From the current conversation: routing weight updates, bundle updates, engram updates, new cross-project knowledge, and user corrections. For each, note what should change (MEMORY.md, a bundle, an engram).
+
+3. **Proposed changes table**  
+   Build a single table: Type (Health/Learn/Fix), File, Change, Fix. Include both health-check fixes and session learnings.
+
+4. **Approve then execute**  
+   Present the table. Ask: “Approve all, or pick by number?” Do **not** write until the user approves. Then apply only approved changes. Re-check line counts after edits.
+
+5. **If nothing to do**  
+   Say: “Memory system healthy. No learnings to persist from this session.”
+
+**Limits:** MEMORY.md 200 lines; bundles 180; engrams 150. Session state: flag stale; suggest cleaning when many active sessions.
+
+**Full procedure:** For edge cases (splits, new engrams, remediation patterns), read `.claude/commands/learn.md` and, for save/load, `.claude/commands/session.md` (session save / session load sections).
+
+**Reminder:** CLAUDE.md and MEMORY.md are live sources. Whenever you need guardrails, routing weights, compact instructions, or project index: **read the file**. Do not copy their content into this rule or rely on an earlier read in the same conversation if the user may have changed them.

--- a/templates/hooks/session-start-write-id.sh
+++ b/templates/hooks/session-start-write-id.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# JitNeuro SessionStart — Write Session ID
+# Fires on every SessionStart (new session, resume, after compact, after /clear).
+# Writes this conversation's session_id to .session-id so commands can resolve
+# "my current" per-session ( .current.d/<id> ) instead of one global .current.
+#
+# No stdout; exit 0. Does not block.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CLAUDE_DIR="$(dirname "$SCRIPT_DIR")"
+SESSION_DIR="$CLAUDE_DIR/session-state"
+SESSION_ID_FILE="$SESSION_DIR/.session-id"
+CURRENT_D_DIR="$SESSION_DIR/.current.d"
+
+# Read hook input
+INPUT=$(cat)
+SESSION_ID=$(echo "$INPUT" | grep -o '"session_id"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | grep -o '"[^"]*"$' | tr -d '"')
+
+# Create session-state and .current.d if needed
+mkdir -p "$SESSION_DIR"
+mkdir -p "$CURRENT_D_DIR"
+
+if [ -n "$SESSION_ID" ]; then
+  printf '%s' "$SESSION_ID" > "$SESSION_ID_FILE"
+fi
+
+exit 0

--- a/templates/jitneuro.json
+++ b/templates/jitneuro.json
@@ -1,18 +1,22 @@
 {
-  "version": "0.1.3",
+  "version": "0.1.4",
   "hooks": {
     "preCompactBehavior": "block",
     "autosave": true,
     "protectedBranches": ["main", "master"],
-    "mainPushAllowed": [
-      "https://github.com/dstolts/jitai-35.git"
-    ],
+    "mainPushAllowed": [],
     "hookEvents": [
       {
         "event": "PreCompact",
         "matcher": "",
         "script": "pre-compact-save.sh",
         "timeout": 10
+      },
+      {
+        "event": "SessionStart",
+        "matcher": "",
+        "script": "session-start-write-id.sh",
+        "timeout": 5
       },
       {
         "event": "SessionStart",

--- a/templates/session-state/README.md
+++ b/templates/session-state/README.md
@@ -2,6 +2,14 @@
 
 One file per named session. Sessions are cross-repo by design.
 
+## Per-session "current" (v0.1.4+)
+
+- **`.session-id`** — Written by SessionStart hook (Claude Code). Contains this conversation's session ID. When present, "current" is resolved from `.current.d/<id>` so multiple chats can each have their own current session.
+- **`.current`** — Legacy: one line = active session name. Fallback when `.session-id` is missing (e.g. Cursor).
+- **`.current.d/<id>`** — One file per conversation; content = session name. Created when save/load/new/switch/rename run with `.session-id` set.
+
+Commands and the Cursor rule resolve "my current" by: if `.session-id` exists, read `.current.d/<id>`; else read `.current`. They write to both when updating current.
+
 ## Usage
 - `/save <name>` creates or updates `<name>.md`
 - `/load <name>` loads from `<name>.md`


### PR DESCRIPTION
## Summary
- **Per-session current tracking:** Multiple Claude Code/Cursor conversations can each have their own active session via `.session-id` + `.current.d/<id>` (fallback to `.current`)
- **Cursor cross-vendor support:** Intent rule, docs, and templates so Cursor users get guardrails, save, load, and learn
- **Bundle line limit 80->180:** Updated across all templates, docs, and commands
- **Session-start-write-id hook:** New 5th hook writes `.session-id` on every SessionStart; installers and docs updated
- **Genericized all owner-specific references:** "Dan" -> "owner", "NEEDS DAN" -> "NEEDS OWNER", removed owner-specific URL from template config
- **Fixed learn.md typos:** Prior bad replace introduced 1180/1150 instead of 180/170
- **Generic project guardrail added** to `.claude/CLAUDE.md`
- **.HUB/ added to .gitignore** (internal per-machine notes)

## Commits (8)
1. `fix: correct bundle limit typos in learn.md (1180->180, 1150->170)`
2. `fix: replace owner-specific name references with generic "owner"`
3. `feat: update bundle line limit from 80 to 180 across templates and docs`
4. `feat: per-session current tracking via .session-id and .current.d`
5. `feat: add session-start-write-id hook with installer and docs`
6. `feat: add generic project guardrail and exclude .HUB from git`
7. `feat: add Cursor cross-vendor support with intent rules and docs`
8. `fix: replace NEEDS DAN convention with NEEDS OWNER across all templates`

## Test plan
- [x] Zero inappropriate "Dan" references remaining (3 appropriate: author credit, guardrail example, completed checklist)
- [x] Zero 1180/1150 typos remaining
- [x] templates/jitneuro.json validates as valid JSON
- [x] All 18 command templates present
- [x] All 5 hook scripts present
- [x] 180 limit referenced in all 8 expected files
- [x] Per-session tracking referenced in session.md, sessions.md, session-state/README.md