### PR TITLE
fix: v0.3.1 -- heartbeat write race condition

### DIFF
--- a/docs/hook-performance.md
+++ b/docs/hook-performance.md
@@ -121,3 +121,11 @@ A common pattern is spawning 5+ research agents simultaneously (find files, sear
 The chain is: **Claude tool call -> hook fires -> bash runs -> bash exits -> Claude continues.** The bash execution is invisible to the hook dispatcher. No recursion is possible.
 
 The only way to create hook recursion would be writing a hook that invokes the `claude` CLI itself (spawning a new Claude Code instance). That would start a separate process with its own session-id and hooks -- not recursion, but an independent session. JitNeuro's hooks never do this.
+
+## Known Gotcha: Write/Edit vs Heartbeat Hook
+
+**Never use Claude Code's Write or Edit tools to modify heartbeat files.** The PostToolUse heartbeat hook touches `heartbeats/<session-id>` after every tool call. If Claude reads the file, then any tool fires (triggering the heartbeat touch), then Claude tries Write/Edit -- it fails with "file modified since read."
+
+**Fix:** All heartbeat writes use Bash `echo -n "<value>" > path` which is atomic and has no read-before-write check. This is documented in session.md's "Write my current" instruction.
+
+This affects: `/load`, `/save`, `/session new`, `/session switch`, `/session rename` -- any command that sets the active session name.

--- a/templates/commands/session.md
+++ b/templates/commands/session.md
@@ -27,7 +27,8 @@ Session identity is stored in `.claude/session-state/heartbeats/<session-id>` --
 3. If the file is missing or empty: no active session.
 
 **Write "my current" (set active session name to `<name>`):**
-1. Write `<name>` (one line) to `.claude/session-state/heartbeats/<session-id>` (session-id from context). Create the `heartbeats/` directory if it does not exist.
+1. Use Bash to write the session name: `echo -n "<name>" > ".claude/session-state/heartbeats/<session-id>"` (session-id from context). Create the `heartbeats/` directory with `mkdir -p` if it does not exist.
+   **IMPORTANT:** Always use Bash for heartbeat writes, never Write/Edit tools. The PostToolUse heartbeat hook touches this file after every tool call, so Write/Edit will fail with "file modified since read." Bash echo is atomic and avoids the race.
 
 **Clear "my current" (e.g. active session was deleted/archived):**
 1. Remove `.claude/session-state/heartbeats/<session-id>` if it exists (session-id from context).

--- a/templates/cursor/rules/jitneuro-intents.mdc
+++ b/templates/cursor/rules/jitneuro-intents.mdc
@@ -52,7 +52,7 @@ This rule defines **guardrails** and three core intents: **save**, **load**, **l
    If the session involves repos with `.HUB/Hub-*.md`, find or create a section headed `## <session-name>` and sync TodoWrite items there (add new, update status). Each session owns its own section. If there are todos and no Hub file, consider creating one.
 
 5. **Update current**
-   Write the session name to `.claude/session-state/heartbeats/<session-id>` (session-id from context). Create the `heartbeats/` directory if it does not exist.
+   Use a shell command to write the session name: `echo -n "<name>" > ".claude/session-state/heartbeats/<session-id>"`. Never use Write/Edit tools for heartbeat files -- the PostToolUse hook touches them constantly, causing "file modified since read" errors.
 
 6. **Confirm**  
    Say something like: “Saved `<name>`. Safe to clear context. Use load to restore.” If the session had learnings, suggest running **learn** next.

--- a/templates/jitneuro.json
+++ b/templates/jitneuro.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0",
+  "version": "0.3.1",
   "hooks": {
     "preCompactBehavior": "block",
     "autosave": true,

--- a/templates/rules/heartbeat-write-safety.md
+++ b/templates/rules/heartbeat-write-safety.md
@@ -1,0 +1,11 @@
+# Heartbeat File Write Safety
+
+NEVER use Write or Edit tools on files in `.claude/session-state/heartbeats/`. Always use Bash:
+
+```bash
+echo -n "<session-name>" > ".claude/session-state/heartbeats/<session-id>"
+```
+
+The PostToolUse heartbeat hook touches these files after every tool call. Write/Edit will fail with "file modified since read" because the hook modifies the file between your Read and your Write. Bash echo is atomic and bypasses this check.
+
+This applies to: `/load`, `/save`, `/session new`, `/session switch`, `/session rename` -- any operation that sets the active session name.


### PR DESCRIPTION
## Summary

- **Heartbeat write race fix** -- `/load`, `/save`, and all session commands that write the heartbeat file now use Bash `echo` instead of Write/Edit tools. The PostToolUse heartbeat hook touches the file after every tool call, causing Write/Edit to fail with "file modified since read."
- **Cursor rules updated** -- same fix applied to jitneuro-intents.mdc
- **Hook performance gotcha documented** -- hook-performance.md now has a "Known Gotcha" section explaining the race and the fix
- **Version bump** -- 0.3.0 -> 0.3.1

## Root Cause

Discovered during live `/load AIFieldSupport-HE` in a separate terminal. The heartbeat.sh PostToolUse hook fires after every tool call (including Read), touching `heartbeats/<session-id>` to update mtime. When Claude then tries Write/Edit on the same file, Claude Code's safety check rejects it because the file was modified between the Read and Write.

## Test Plan (method: live /load in separate terminal)

- [x] `/load` fails with Write/Edit on heartbeat file (method: reproduced in live terminal -- 3 consecutive Write/Edit failures)
- [x] Bash `echo -n` writes heartbeat atomically (method: manual bash test -- no race possible since no read-before-write check)
- [x] Session commands updated to use Bash (method: code review of session.md "Write my current" instruction)
- [x] Cursor rules updated (method: code review of jitneuro-intents.mdc step 5)