### PR TITLE
feat: v0.4.0 scheduled agents + test-tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ JIT memory management framework for Claude Code -- persistent context across ses
 ## Key Paths
 | Path | Purpose |
 |------|---------|
-| templates/commands/ | Slash command templates (17 files: 12 commands + 5 shortcuts) |
+| templates/commands/ | Slash command templates (20 files: 14 commands + 5 shortcuts + test-tools) |
 | templates/hooks/ | Hook script templates (4 hooks) |
 | templates/engrams/ | Engram templates + examples |
 | templates/rules/ | Path-scoped rule templates |
@@ -24,7 +24,7 @@ JIT memory management framework for Claude Code -- persistent context across ses
 | install.sh / install.ps1 | Installation scripts (workspace/project/user modes) |
 
 ## Key Components
-- 12 commands: session, sessions, learn, health, gitstatus, diff, enterprise, audit, bundle, onboard, orchestrate, conversation-log
+- 14 commands: session, sessions, learn, health, gitstatus, diff, enterprise, audit, bundle, onboard, orchestrate, conversation-log, test-tools, schedule
 - 5 shortcuts: save, load, pulse, status, dashboard (delegate to session/sessions based on preference)
 - 4 hooks: PreCompact save, SessionStart recovery, Branch protection, SessionEnd auto-save
 - Engram system: per-project deep context files (50-150 lines each)

--- a/PRDs/scheduled-agents.md
+++ b/PRDs/scheduled-agents.md
@@ -1,0 +1,199 @@
+# PRD: Scheduled Agents System
+
+**Feature:** Scheduled Agents (Timer Agent Pattern)
+**Version:** v0.4.0
+**Status:** Approved
+**Date:** 2026-03-24
+**GitHub Issue:** #16 (autosave), new issue for system
+
+## Problem
+
+Master gets tunnel vision during deep coding work. It forgets housekeeping:
+- Session state goes unsaved for hours
+- TodoWrite and Hub.md drift out of sync with actual progress
+- Deploy failures go unnoticed
+- Users return to stale status boards
+
+Manual discipline fails because master deprioritizes housekeeping under cognitive load.
+The PreCompact hook only fires at compaction -- not on a regular interval.
+
+## Solution
+
+A generic **scheduled agent system** that spawns lightweight timer agents. Each agent sleeps for a configured interval, then returns an instruction that master MUST execute immediately. The agent is an interrupt mechanism -- it forces master to stop current work and do housekeeping.
+
+## Architecture
+
+### Timer Agent Pattern
+
+```
+Master (session start) -> spawns timer agent (background)
+Timer agent: sleep N minutes -> return INSTRUCTION -> dies
+Master: receives notification -> executes instruction -> re-spawns timer
+```
+
+### Constraints (verified)
+- Subagents CANNOT spawn subagents (no Agent tool available)
+- Bash sleep max 600s per call (chain for longer intervals)
+- Agent context is fixed-size per instance (never grows)
+- Master is the only entity that can spawn agents
+
+### Why Agent Does NOT Do The Work
+The agent is a timer + instruction generator. Master does the actual work because:
+1. Master has full session context (knows what changed, what's dirty)
+2. Master has the TodoWrite state in memory
+3. Master can run /save with full context
+4. Agent doing heavy reads/writes would grow its context needlessly
+
+## Config Schema
+
+`jitneuro.json` new top-level key:
+
+```json
+{
+  "scheduledAgents": [
+    {
+      "name": "autosave",
+      "interval": 30,
+      "enabled": true,
+      "instruction": "/save",
+      "description": "Auto-save session state every 30 minutes"
+    },
+    {
+      "name": "hub-sync",
+      "interval": 10,
+      "enabled": true,
+      "instruction": "UPDATE_HUB",
+      "prompt": "Check if TodoWrite tasks and Hub.md are in sync with current work. If drift detected, update both. Report what changed.",
+      "description": "Keep TodoWrite and Hub.md current every 10 minutes"
+    }
+  ]
+}
+```
+
+Fields:
+- `name`: unique identifier
+- `interval`: minutes between cycles (chains sleep 600 calls)
+- `enabled`: boolean, can be toggled at runtime via /schedule
+- `instruction`: what master should do. Either a slash command or a keyword:
+  - `/save`, `/health`, etc. -- run the command
+  - `UPDATE_HUB` -- sync TodoWrite to Hub.md
+  - `ASK_USER <message>` -- surface a question to the user
+  - `NONE` -- log only, no action (for monitoring agents)
+- `prompt` (optional): for smart agents, additional context the timer agent evaluates before returning. If prompt is set, the agent reads state and may override the default instruction.
+- `description`: human-readable purpose
+
+## User Stories
+
+### US-001: Auto-launch scheduled agents on session start
+**As a** user loading a session
+**I want** all enabled scheduled agents to start automatically
+**So that** I get housekeeping interrupts without remembering to start them
+
+**Acceptance criteria:**
+- SessionStart hook reads scheduledAgents from jitneuro.json
+- For each enabled agent, master spawns a background timer agent
+- Agents begin their first sleep cycle immediately
+- No user action required
+
+### US-002: Autosave agent (default, 30 min)
+**As a** user in a long session
+**I want** session state saved automatically every 30 minutes
+**So that** I never lose more than 30 minutes of context on crash/compact
+
+**Acceptance criteria:**
+- Timer agent sleeps 30 minutes, returns INSTRUCTION: /save
+- Master executes /save immediately on receiving the instruction
+- Master re-spawns the timer agent
+- Runs indefinitely until session ends or user stops it
+
+### US-003: Hub-sync agent (default, 10 min)
+**As a** user deep in coding
+**I want** TodoWrite and Hub.md kept in sync automatically
+**So that** my task status is always accurate for /dashboard and session recovery
+
+**Acceptance criteria:**
+- Timer agent sleeps 10 minutes
+- On wake, reads TaskList and Hub.md, checks for drift
+- Returns INSTRUCTION: UPDATE_HUB if drift detected, NONE if in sync
+- Master updates Hub.md immediately when instructed
+- Master re-spawns the timer agent
+
+### US-004: /schedule command for runtime management
+**As a** user
+**I want** to list, start, stop, add, and remove scheduled agents at runtime
+**So that** I can control which agents are active without editing config
+
+**Acceptance criteria:**
+- `/schedule` or `/schedule list` -- show all agents with status (running/stopped/enabled/disabled)
+- `/schedule start <name>` -- spawn the timer agent now
+- `/schedule stop <name>` -- mark as stopped (do not re-spawn on next return)
+- `/schedule add <name> <interval> <instruction>` -- add a new agent to config
+- `/schedule remove <name>` -- remove from config
+
+### US-005: Mandatory interrupt guardrail
+**As a** user who configured scheduled agents
+**I want** master to ALWAYS obey the agent's instruction immediately
+**So that** housekeeping actually happens even when master is deep in work
+
+**Acceptance criteria:**
+- Guardrail rule loaded every session
+- Master stops current work when scheduled agent returns
+- Master executes instruction before resuming
+- No confirmation needed -- scheduled agents are user-configured and trusted
+
+### US-006: Smart agent with prompt evaluation
+**As a** user
+**I want** some scheduled agents to evaluate state before returning
+**So that** unnecessary interrupts are avoided (e.g., hub-sync skips if already in sync)
+
+**Acceptance criteria:**
+- If agent config has `prompt`, agent executes the prompt logic on wake
+- Agent may return INSTRUCTION: NONE if no action needed
+- Master still re-spawns the timer (NONE means "nothing this cycle")
+
+## Timer Agent Prompt Template
+
+### Simple (command-only):
+```
+You are a timer for scheduled agent "{name}".
+Your job: sleep, then return one instruction. Nothing else.
+
+SLEEP: {interval} minutes. Use chained `sleep 600` bash calls.
+For {interval} min: {sleep_chain}
+
+When you wake, return EXACTLY:
+SCHEDULED: {name}
+INSTRUCTION: {instruction}
+
+Do no other work. Do not read files. Do not analyze anything.
+Just sleep and return.
+```
+
+### Smart (with prompt):
+```
+You are a timer for scheduled agent "{name}".
+Your job: sleep, evaluate, then return one instruction.
+
+SLEEP: {interval} minutes. Use chained `sleep 600` bash calls.
+For {interval} min: {sleep_chain}
+
+When you wake:
+{prompt}
+
+Then return one of:
+SCHEDULED: {name}
+INSTRUCTION: {resolved_instruction}
+CONTEXT: {brief explanation if relevant}
+
+Or if no action needed:
+SCHEDULED: {name}
+INSTRUCTION: NONE
+
+Keep evaluation lightweight. Read at most 2-3 files. Decide fast.
+```
+
+## Out of Scope (v0.4.0)
+- Agent-to-agent communication (future: agents coordinating schedules)
+- Persistent agent state across re-spawns (each instance is fresh)
+- Web UI for schedule management
+- Cron-style scheduling (just intervals for now)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > This started because reloading context after every /clear got old.
 > If it helps you, share what you learn.
 
-**Status: v0.2.0 -- 12 commands, 5 shortcuts, 6 hooks, 16 personas, 4 decision models, cognition layer**
+**Status: v0.4.0 -- 14 commands, 5 shortcuts, 7 hooks, 16 personas, 4 decision models, cognition layer, scheduled agents**
 **GitHub:** [github.com/dstolts/jitneuro](https://github.com/dstolts/jitneuro)
 
 **JIT = Just In Time.** A framework for managing short-term and long-term memory
@@ -125,7 +125,8 @@ repos, use **user** mode so commands are available everywhere.
 
 ## What's Included
 
-- **12 commands + 5 shortcuts** -- session (/session, /sessions), memory (/learn, /health, /bundle), governance (/enterprise, /audit), git (/gitstatus, /diff), setup (/onboard, /orchestrate, convlog, /verify). Shortcuts: /save, /load, /pulse, /status, /dashboard
+- **14 commands + 5 shortcuts** -- session (/session, /sessions), memory (/learn, /health, /bundle), governance (/enterprise, /audit), git (/gitstatus, /diff), setup (/onboard, /orchestrate, convlog, /verify), diagnostics (/test-tools), automation (/schedule). Shortcuts: /save, /load, /pulse, /status, /dashboard
+- **Scheduled agents** -- timer agents that interrupt master with housekeeping instructions on a configurable interval. Ships with autosave (30m) and hub-sync (10m) by default.
 - **6 hooks** -- pre-compact save, session recovery, post-clear session picker, branch protection, auto-save, session ID tracking
 - **16 personas** -- expert roles that evaluate every request (Security Engineer, DBA, Content Strategist, QA, etc.)
 - **Friction detection** -- pre-reasoning scan for user correction signals with severity-ordered response

--- a/docs/commands-reference.md
+++ b/docs/commands-reference.md
@@ -1,6 +1,6 @@
 # Commands Reference
 
-JitNeuro ships 12 commands and 5 shortcuts organized into 5 categories. All commands are read-only unless explicitly noted.
+JitNeuro ships 14 commands and 5 shortcuts organized into 6 categories. All commands are read-only unless explicitly noted.
 
 ---
 
@@ -201,6 +201,53 @@ Example:
 /conversation-log on
 ```
 Enables conversation logging with timestamped filenames.
+
+---
+
+## Diagnostics
+
+### /test-tools
+Smoke-test every available Claude Code tool and MCP server. Auto-discovers connected MCP servers and runs one safe read-only operation per server. Reports PASS/FAIL/SKIP for each tool.
+
+- **Core tools tested:** Bash, Read, Write, Edit, Glob, Grep, Agent, WebFetch, WebSearch, TaskCreate
+- **MCP servers:** Auto-discovered via ToolSearch -- no hardcoded list
+- **Side effects:** Creates one temp file (cleaned up), creates one temp task (deleted)
+- **Output:** ASCII table with PASS/FAIL/SKIP counts and remediation hints for failures
+
+Example:
+```
+/test-tools
+```
+
+---
+
+## Automation
+
+### /schedule [list|start|stop|add|remove]
+Manage scheduled agents -- background timer agents that periodically interrupt master with housekeeping instructions.
+
+- **Subcommands:**
+  - `list` (default) -- show all agents with status (RUNNING/STOPPED/DISABLED)
+  - `start <name>` -- spawn the timer agent now
+  - `stop <name>` -- stop re-spawning after current timer expires
+  - `add <name> <interval> <instruction> [description]` -- add new agent to config
+  - `remove <name>` -- remove from config
+
+- **Default agents (ship with jitneuro):**
+  - `autosave` (30m) -- runs /save every 30 minutes
+  - `hub-sync` (10m) -- checks TodoWrite vs Hub.md drift every 10 minutes
+
+- **Architecture:** Timer agent pattern. Agent sleeps for interval, returns instruction, dies. Master executes instruction and re-spawns. Agent context never grows. Runs indefinitely.
+
+- **Guardrail:** Scheduled agent interrupts are MANDATORY. Master stops current work immediately and executes the instruction before resuming. See `rules/scheduled-agent-interrupts.md`.
+
+Examples:
+```
+/schedule                    -- list all agents and status
+/schedule start autosave     -- start the autosave timer
+/schedule stop hub-sync      -- stop hub-sync after current cycle
+/schedule add deploy-mon 5 NONE "Poll deploy pipeline"
+```
 
 ---
 

--- a/templates/commands/schedule.md
+++ b/templates/commands/schedule.md
@@ -1,0 +1,133 @@
+# Schedule
+
+Manage scheduled agents -- background timer agents that periodically interrupt master with housekeeping instructions.
+
+## Instructions
+
+When invoked as `/schedule`:
+
+### /schedule or /schedule list (default)
+
+1. Read `scheduledAgents` from `.claude/jitneuro.json`
+2. Check which agents are currently running (check for active background agents by name)
+3. Display status table:
+
+```
+Scheduled Agents:
+  #  Name        Interval  Status    Instruction         Description
+  1  autosave    30m       RUNNING   /save               Auto-save session state
+  2  hub-sync    10m       STOPPED   UPDATE_HUB          Keep TodoWrite and Hub.md current
+  3  deploy-mon  5m        DISABLED  NONE (monitoring)    Poll deploy pipeline
+
+Tip: /schedule start|stop <name>, /schedule add|remove <name>
+```
+
+Status values:
+- `RUNNING` -- timer agent is currently spawned and sleeping
+- `STOPPED` -- enabled in config but not currently spawned (user stopped it, or not yet started)
+- `DISABLED` -- `enabled: false` in config
+
+### /schedule start <name>
+
+1. Find the agent config by name in scheduledAgents
+2. If not found: "No scheduled agent named '<name>'. Use /schedule add to create one."
+3. If already running: "Agent '<name>' is already running."
+4. Calculate sleep chain: `interval / 10` rounded up = number of `sleep 600` calls. Remainder handled by a shorter final sleep.
+5. Spawn the timer agent as a background Agent:
+
+**For simple agents (no prompt field):**
+```
+Agent(
+  run_in_background: true,
+  description: "scheduled: <name>",
+  prompt: """
+You are a timer for scheduled agent "<name>".
+Your ONLY job: sleep, then return one instruction. Nothing else.
+
+SLEEP: <interval> minutes.
+<sleep_instructions>
+
+When you wake, return EXACTLY this and nothing else:
+SCHEDULED: <name>
+INSTRUCTION: <instruction>
+
+Do no other work. Do not read files. Do not analyze anything. Just sleep and return.
+"""
+)
+```
+
+**For smart agents (has prompt field):**
+```
+Agent(
+  run_in_background: true,
+  description: "scheduled: <name>",
+  prompt: """
+You are a timer for scheduled agent "<name>".
+Your job: sleep, evaluate briefly, then return one instruction.
+
+SLEEP: <interval> minutes.
+<sleep_instructions>
+
+When you wake, evaluate:
+<prompt from config>
+
+Then return ONE of these formats:
+
+If action needed:
+SCHEDULED: <name>
+INSTRUCTION: <instruction from config>
+CONTEXT: <one line explaining why>
+
+If no action needed:
+SCHEDULED: <name>
+INSTRUCTION: NONE
+
+Keep evaluation lightweight. Read at most 2-3 files. Decide in under 10 seconds.
+"""
+)
+```
+
+**Sleep instruction generation:**
+- interval <= 10: `Run: sleep <interval * 60>`
+- interval 20: `Run these in sequence: sleep 600 then sleep 600`
+- interval 30: `Run these in sequence: sleep 600 then sleep 600 then sleep 600`
+- interval N: chain `sleep 600` calls, final call is `sleep <remainder * 60>` if not evenly divisible
+
+6. Confirm: "Started scheduled agent '<name>' (every <interval>m). Next interrupt in ~<interval> minutes."
+
+### /schedule stop <name>
+
+1. Mark the agent as stopped in the session's runtime state
+2. Note: the currently sleeping agent will still return when it wakes. When it does, the scheduled-agent-interrupts rule checks if it's stopped and skips re-spawn.
+3. Confirm: "Stopped scheduled agent '<name>'. Current timer will expire without re-spawn."
+
+### /schedule add <name> <interval> <instruction> [description]
+
+1. Validate: name is unique, interval is a positive number
+2. Add to scheduledAgents array in jitneuro.json:
+```json
+{
+  "name": "<name>",
+  "interval": <interval>,
+  "enabled": true,
+  "instruction": "<instruction>",
+  "description": "<description or 'Custom scheduled agent'>"
+}
+```
+3. Ask: "Start '<name>' now? (yes/no)"
+4. If yes: run /schedule start <name>
+
+### /schedule remove <name>
+
+1. Find agent in config
+2. If running, stop it first
+3. Remove from scheduledAgents array in jitneuro.json
+4. Confirm: "Removed scheduled agent '<name>' from config."
+
+## Important
+- Scheduled agents are one-shot timer agents. They sleep once, return once, die. Master re-spawns them per the guardrail rule.
+- The /schedule command manages config and spawns. The guardrail rule in scheduled-agent-interrupts.md handles the interrupt + re-spawn cycle.
+- Sleep uses chained `sleep 600` (10 min max per bash call). Forward slashes in all paths.
+- Agent descriptions use "scheduled: <name>" prefix so they're identifiable in agent lists.
+- Smart agents (with prompt) should keep evaluation under 10 seconds and read at most 2-3 files.
+- Do not spawn agents for disabled entries (enabled: false).

--- a/templates/commands/test-tools.md
+++ b/templates/commands/test-tools.md
@@ -1,0 +1,115 @@
+# Test Tools
+
+Smoke-test every available Claude Code tool and MCP server. Reports PASS/FAIL for each.
+Diagnostic only -- creates one temp file, then deletes it. No other side effects.
+
+## Instructions
+
+When invoked as `/test-tools`:
+
+Run ALL tests below. Use parallel tool calls where possible (group independent tests together).
+For each test, catch errors gracefully -- a failure in one test must NOT stop the others.
+
+Report results in this format at the end:
+```
+Tool Test Results (YYYY-MM-DD HH:MM)
+=============================================
+CORE TOOLS
+  [PASS] Bash            -- echo worked
+  [PASS] Read            -- read CLAUDE.md (N lines)
+  [PASS] Write           -- created temp file
+  [PASS] Edit            -- edited temp file
+  [PASS] Glob            -- found N .md files
+  [PASS] Grep            -- pattern matched in N files
+  [PASS] Agent           -- subagent returned OK
+  [PASS] WebFetch        -- fetched URL (status 200)
+  [PASS] WebSearch       -- returned N results
+  [PASS] TaskCreate      -- task created and deleted
+
+MCP SERVERS
+  [PASS] github:get_me           -- authenticated as <user>
+  [PASS] filesystem:list_dir     -- listed N items
+  [SKIP] some-server:some_tool   -- not connected
+  [FAIL] broken:tool_name        -- error: <message>
+
+SUMMARY: 14/16 PASS, 1 FAIL, 1 SKIP
+=============================================
+```
+
+### Phase 1: Core Tools
+
+All core tool tests use paths relative to the current working directory or well-known safe targets.
+Use forward slashes in ALL Bash tool paths (Windows bash treats backslashes as escape characters).
+
+**Batch 1 (independent, run in parallel):**
+1. **Bash**: `echo "tool-test-ok"` -- PASS if output contains "tool-test-ok"
+2. **Read**: Read first 5 lines of the nearest CLAUDE.md (check CWD, then CWD/.claude/, then parent dirs) -- PASS if content returned
+3. **Glob**: `**/*.md` in the current working directory -- PASS if any files found
+4. **Grep**: Search for a common word like "the" in the nearest CLAUDE.md -- PASS if matches found
+5. **WebFetch**: Fetch https://httpbin.org/get -- PASS if response received
+6. **WebSearch**: Search "Claude Code" -- PASS if results returned
+
+**Batch 2 (sequential write/edit/read cycle):**
+7. **Write**: Create `.claude/test-tools-temp.md` in CWD (or CWD/.test-tools-temp.md if no .claude/) with content "test-write-ok" -- PASS if created
+8. **Edit**: Replace "test-write-ok" with "test-edit-ok" in the temp file -- PASS if succeeded
+9. **Read verify**: Read the temp file, confirm it contains "test-edit-ok" -- PASS if matched
+10. **Bash cleanup**: Delete the temp file using `rm` with forward-slash path -- silent cleanup
+
+**Batch 3 (independent):**
+11. **TaskCreate**: Create a task "Test task - auto-delete" -- PASS if task ID returned. Immediately delete it (TaskUpdate status: deleted).
+12. **Agent**: Spawn a quick subagent (subagent_type: Explore) with prompt "Return STATUS: OK and nothing else" -- PASS if returns STATUS: OK
+
+### Phase 2: MCP Server Auto-Discovery
+
+Do NOT hardcode MCP server names. Instead, auto-discover what's available:
+
+1. Use **ToolSearch** with a broad query like `"mcp"` (max_results: 50) to discover all available MCP tools
+2. Parse the results to identify unique MCP server prefixes (the part between `mcp__` and the next `__`)
+3. For each discovered server, pick ONE safe read-only tool to test:
+
+**Server selection heuristics (pick the first match):**
+| Server prefix contains | Test tool pattern | Test input |
+|------------------------|-------------------|------------|
+| github | `get_me` | (no args) |
+| filesystem | `list_directory` or `list_allowed_directories` | CWD path |
+| azure-sql | `subscription_list` | (no args) |
+| stripe | `get_stripe_account_info` or `list_products` | (no args, or limit 1) |
+| salesforce | `salesforce_search_objects` | searchPattern: "Account" |
+| firebase | `firebase_list_projects` | (no args) |
+| ms-learn-docs | `microsoft_docs_search` | query: "Azure" |
+| context7 | `resolve-library-id` | libraryName: "react", query: "react docs" |
+| ai-diagnostics | `test_environment` | environment: "uat" |
+| (any other) | Pick the first tool that looks read-only (list, get, search, describe, read, fetch) | Minimal safe args |
+
+4. For each server, use **ToolSearch** to fetch the specific tool schema, then call it
+5. If a tool call succeeds: `[PASS]`
+6. If a tool call errors: `[FAIL]` with first line of error
+7. If ToolSearch returns no tools for a server: `[SKIP] -- not connected`
+
+### Phase 3: Report
+
+After all tests complete, compile the results table shown above.
+
+Include:
+- Total counts: PASS, FAIL, SKIP
+- For any FAIL, include a one-line remediation hint:
+  - Auth errors: "Re-authenticate (e.g., sf org login, az login, check API key)"
+  - Connection errors: "Check MCP server config in .mcp.json or settings"
+  - Unknown tool errors: "MCP server may need restart or update"
+  - Path errors: "Check file exists and path uses forward slashes"
+
+### Error Handling
+- If a ToolSearch fails to find a tool schema: `[SKIP] <server> -- schema not available`
+- If a tool call throws: `[FAIL] <server>:<tool> -- <error first line>`
+- If a tool call times out: `[FAIL] <server>:<tool> -- timeout`
+- Never let one failure stop the rest of the tests
+- Always clean up the temp file, even if Edit fails
+
+### Important
+- This command is diagnostic -- minimize side effects
+- Delete any test tasks created during the run
+- Do not modify any real data via MCP servers (read-only operations only)
+- Maximize parallelism -- run all independent tests simultaneously
+- Use forward slashes in ALL Bash paths
+- Works from any working directory -- no hardcoded paths
+- MCP server list is dynamic -- new servers are auto-detected

--- a/templates/hooks/session-start-scheduled-agents.sh
+++ b/templates/hooks/session-start-scheduled-agents.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# JitNeuro SessionStart Hook: Scheduled Agents Launcher
+# Reads scheduledAgents config from jitneuro.json and injects launch instructions
+# into Claude's context. Claude (master) then spawns the timer agents.
+#
+# stdout goes into Claude's context window as injected context.
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" 2>/dev/null && pwd)"
+CLAUDE_DIR="$(dirname "$SCRIPT_DIR")"
+CONFIG="$CLAUDE_DIR/jitneuro.json"
+
+# Exit silently if no config
+[ ! -f "$CONFIG" ] && exit 0
+
+# Check if scheduledAgents key exists
+if ! grep -q '"scheduledAgents"' "$CONFIG" 2>/dev/null; then
+  exit 0
+fi
+
+# Extract enabled agents using basic text parsing (no jq dependency)
+# Look for entries where "enabled": true
+AGENTS=""
+IN_AGENTS=false
+CURRENT_NAME=""
+CURRENT_INTERVAL=""
+CURRENT_INSTRUCTION=""
+CURRENT_PROMPT=""
+CURRENT_ENABLED=""
+CURRENT_DESC=""
+AGENT_COUNT=0
+
+while IFS= read -r line; do
+  # Detect scheduledAgents array
+  if echo "$line" | grep -q '"scheduledAgents"'; then
+    IN_AGENTS=true
+    continue
+  fi
+
+  # Exit array on closing bracket at same indent level
+  if $IN_AGENTS && echo "$line" | grep -qE '^\s*\]'; then
+    # Flush last agent
+    if [ -n "$CURRENT_NAME" ] && [ "$CURRENT_ENABLED" = "true" ]; then
+      AGENT_COUNT=$((AGENT_COUNT + 1))
+      AGENTS="${AGENTS}
+  - name: ${CURRENT_NAME}, interval: ${CURRENT_INTERVAL}m, instruction: ${CURRENT_INSTRUCTION}"
+      if [ -n "$CURRENT_PROMPT" ]; then
+        AGENTS="${AGENTS}, prompt: ${CURRENT_PROMPT}"
+      fi
+    fi
+    IN_AGENTS=false
+    continue
+  fi
+
+  if ! $IN_AGENTS; then
+    continue
+  fi
+
+  # New agent object
+  if echo "$line" | grep -q '{'; then
+    # Flush previous agent
+    if [ -n "$CURRENT_NAME" ] && [ "$CURRENT_ENABLED" = "true" ]; then
+      AGENT_COUNT=$((AGENT_COUNT + 1))
+      AGENTS="${AGENTS}
+  - name: ${CURRENT_NAME}, interval: ${CURRENT_INTERVAL}m, instruction: ${CURRENT_INSTRUCTION}"
+      if [ -n "$CURRENT_PROMPT" ]; then
+        AGENTS="${AGENTS}, prompt: ${CURRENT_PROMPT}"
+      fi
+    fi
+    CURRENT_NAME=""
+    CURRENT_INTERVAL=""
+    CURRENT_INSTRUCTION=""
+    CURRENT_PROMPT=""
+    CURRENT_ENABLED=""
+    CURRENT_DESC=""
+    continue
+  fi
+
+  # Parse fields
+  val=$(echo "$line" | sed 's/.*: *"\{0,1\}\([^",}]*\)"\{0,1\}.*/\1/')
+  if echo "$line" | grep -q '"name"'; then
+    CURRENT_NAME="$val"
+  elif echo "$line" | grep -q '"interval"'; then
+    CURRENT_INTERVAL="$val"
+  elif echo "$line" | grep -q '"instruction"'; then
+    CURRENT_INSTRUCTION="$val"
+  elif echo "$line" | grep -q '"enabled"'; then
+    CURRENT_ENABLED="$val"
+  elif echo "$line" | grep -q '"description"'; then
+    CURRENT_DESC="$val"
+  elif echo "$line" | grep -q '"prompt"'; then
+    CURRENT_PROMPT="$val"
+  fi
+
+done < "$CONFIG"
+
+# Nothing to launch
+if [ "$AGENT_COUNT" -eq 0 ]; then
+  exit 0
+fi
+
+cat <<EOF
+[JitNeuro] Scheduled agents configured (${AGENT_COUNT} enabled):
+${AGENTS}
+
+Launch these now using /schedule start <name> for each, or run /schedule to see all.
+To auto-launch all enabled agents, run: /schedule start-all
+EOF
+
+exit 0

--- a/templates/rules/scheduled-agent-interrupts.md
+++ b/templates/rules/scheduled-agent-interrupts.md
@@ -1,0 +1,42 @@
+# Scheduled Agent Interrupts (MANDATORY)
+
+Scheduled agents are user-configured timer agents that periodically return instructions to master. They exist because master forgets housekeeping during deep work. Their interrupts are mandatory.
+
+## When a background scheduled agent returns
+
+1. **STOP current work immediately** -- mid-sentence, mid-tool, mid-plan. Do not finish the current thought first.
+2. **Read the INSTRUCTION** from the agent's return message.
+3. **Execute the instruction FIRST**, before resuming any previous work:
+   - `INSTRUCTION: /save` -- run /save now
+   - `INSTRUCTION: /health` -- run /health now
+   - `INSTRUCTION: UPDATE_HUB` -- sync TodoWrite state to Hub.md now. Read TaskList, compare to Hub.md, update Hub.md to match current task status.
+   - `INSTRUCTION: ASK_USER <message>` -- surface the message to the user immediately
+   - `INSTRUCTION: NONE` -- no action needed this cycle, just re-spawn
+   - `INSTRUCTION: <any slash command>` -- run that command now
+4. **Re-spawn the timer agent** with the same config (unless user ran `/schedule stop <name>` or the agent's `enabled` is false in jitneuro.json).
+5. **Resume previous work** where you left off.
+
+## Why this rule exists
+
+Master gets tunnel vision during deep coding. It deprioritizes housekeeping (saving, status updates, Hub.md) when focused on implementation. Scheduled agents are the interrupt mechanism that forces discipline. If master delays or ignores the instruction, the entire system fails.
+
+## Priority order
+
+```
+User input > Scheduled agent interrupt > Current task
+```
+
+Treat a scheduled agent return the same way you treat a new user message arriving mid-work: handle it NOW.
+
+## Trust model
+
+Scheduled agents are defined in the user's jitneuro.json config. They are trusted. Execute their instructions without asking for confirmation. The user already approved these when they configured them.
+
+## Re-spawn protocol
+
+After executing the instruction, immediately spawn a fresh background timer agent with the same name, interval, and prompt from the scheduledAgents config. The agent is one-shot by design -- each instance sleeps once, returns once, dies. Master re-spawns create the loop.
+
+Do NOT re-spawn if:
+- User explicitly ran `/schedule stop <name>`
+- The agent's `enabled` field is false in jitneuro.json
+- The session is ending


### PR DESCRIPTION
## Summary
- **Scheduled agents system**: Generic timer agent pattern that interrupts master with housekeeping instructions on a configurable interval. Agent sleeps, returns one instruction, dies. Master executes and re-spawns. Zero overhead during sleep.
- **Two default agents**: autosave (30m /save) and hub-sync (10m TodoWrite/Hub.md sync)
- **/schedule command**: list, start, stop, add, remove scheduled agents at runtime
- **/test-tools command**: smoke-test all Claude Code tools + auto-discover and test MCP servers
- **Mandatory interrupt guardrail**: forces master to stop current work and obey agent instructions immediately
- **SessionStart hook**: auto-detects enabled agents and prompts launch

## New files
- `PRDs/scheduled-agents.md` -- full PRD with 6 user stories
- `templates/commands/schedule.md` -- /schedule command
- `templates/commands/test-tools.md` -- /test-tools diagnostic
- `templates/hooks/session-start-scheduled-agents.sh` -- auto-launch hook
- `templates/rules/scheduled-agent-interrupts.md` -- mandatory interrupt rule

## Architecture
```
Master (session start) -> spawns timer agent (background)
Timer agent: sleep N min -> return INSTRUCTION -> dies
Master: receives notification -> executes instruction -> re-spawns
```
Subagents cannot spawn subagents (verified). Agent is a dumb timer. Master does all work. Agent context is fixed-size per instance.

## Config (jitneuro.json)
```json
{
  "scheduledAgents": [
    { "name": "autosave", "interval": 30, "instruction": "/save" },
    { "name": "hub-sync", "interval": 10, "instruction": "UPDATE_HUB", "prompt": "..." }
  ]
}
```

## Related issues
- Closes #17
- Supersedes #16 (autosave is now one instance of generic system)

## Test plan
- [ ] Start new session, verify hook announces scheduled agents
- [ ] Run `/schedule list` -- both agents shown
- [ ] Run `/schedule start autosave` -- timer agent spawns in background
- [ ] Wait 30 min (or reduce interval for testing) -- verify /save fires
- [ ] Run `/schedule stop autosave` -- verify no re-spawn after current timer
- [ ] Run `/test-tools` -- verify all core tools and MCP servers tested
- [ ] Run `/schedule add test-agent 1 NONE "test"` -- verify added to config