### PR TITLE
fix: bundle limit 180->280, clarify soft limit wording

### DIFF
--- a/templates/commands/bundle.md
+++ b/templates/commands/bundle.md
@@ -39,7 +39,7 @@ a. **Look for context to build from.** Search the workspace for a repo, director
 
 b. **If source material found:** Analyze it (package.json, README, CLAUDE.md,
    key files, recent commits, engram) and draft a bundle. A good bundle is
-   50-180 lines covering:
+   50-280 lines covering:
    - Identity (what is this, one line)
    - Architecture (how it's structured, key patterns)
    - Key Files (table: path, purpose -- most important files only)
@@ -68,7 +68,7 @@ Bundles:
 | Bundle | Lines | Status | Description |
 |--------|-------|--------|-------------|
 | active-work | 42 | OK | Current sprints, blockers |
-| blog-content | 61 | WARN | Approaching 180-line limit |
+| blog-content | 61 | WARN | Approaching 280-line limit |
 | deploy | -- | MISSING | In manifest but no file |
 | new-thing | 35 | UNLISTED | File exists, not in manifest |
 
@@ -87,11 +87,11 @@ If the user says "refresh", "update", or "rebuild" in the context of a bundle
 2. Re-analyze the source (repo, engram, recent commits, current files)
 3. Show a diff of what changed (added/removed/updated sections)
 4. Ask for approval before overwriting
-5. After writing, verify line count is under 180
+5. After writing, verify line count is under 280
 
 ## Splitting a Bundle
 
-If a bundle is over 180 lines, or the user asks to split:
+If a bundle is over 280 lines, or the user asks to split:
 
 1. Identify natural subdomain boundaries in the content
 2. Propose split: `<name>-a.md` and `<name>-b.md` with clear names
@@ -101,7 +101,7 @@ If a bundle is over 180 lines, or the user asks to split:
 
 ## Important
 - Always ask before writing or modifying bundle files.
-- Keep bundles under 180 lines. Over 180 means Claude may skip content.
+- Target: under 280 lines. Claude reads the full file regardless of length, but shorter bundles load faster and waste fewer tokens when loaded for the wrong task.
 - One bundle = one domain. If a bundle covers two unrelated things, split it.
 - After any write, update context-manifest.md to match reality.
 - Routing weights live in MEMORY.md -- suggest entries but let the user approve.

--- a/templates/commands/health.md
+++ b/templates/commands/health.md
@@ -11,30 +11,31 @@ Health is not context-dependent -- it reads files on disk, not conversation stat
 
 ## Quick Health (`/health`)
 
-Dispatch to subagent. Read at most 5 files. No conversation context needed.
-
-### Checks
-
-1. **MEMORY.md** -- Read file, count lines. OK < 170, WARN 170-199, CRITICAL 200+.
-2. **Sessions** -- Count files in `.claude/session-state/` (exclude archive/, heartbeats/, .preferences, README.md, _autosave.md). OK < 10, WARN 10+. Flag any >7 days as STALE.
-3. **Bundles** -- Count files in `.claude/bundles/`. Report count only (no line counts).
-4. **Engrams** -- Count files in `.claude/engrams/`. Report count only.
-5. **jitneuro.json** -- Check file exists and `version` field is present.
-
-### Output
+Launch a background **general-purpose** Agent with this prompt:
 
 ```
-Quick Health:
+You are running a JitNeuro quick health check. Read these 5 things and return a table.
+
+1. Read MEMORY.md (the auto-memory file). Count lines. OK < 170, WARN 170-199, CRITICAL 200+.
+2. Count .md files in .claude/session-state/ (exclude archive/, heartbeats/, .preferences, README.md, _autosave.md). OK < 10, WARN 10+. Check file dates -- flag any >7 days as STALE.
+3. Count .md files in .claude/bundles/. Report count only.
+4. Count .md files in .claude/engrams/. Report count only.
+5. Read .claude/jitneuro.json. Check it exists and has a version field.
+
+Return EXACTLY this format:
+QUICK_HEALTH:
 | Component | Status | Detail |
 |-----------|--------|--------|
-| MEMORY.md | OK | 79/200 lines |
-| Sessions | WARN | 12 sessions (10 limit), 2 stale |
-| Bundles | OK | 15 bundles |
-| Engrams | OK | 27 engrams |
-| jitneuro.json | OK | v0.4.0 |
+| MEMORY.md | OK/WARN/CRITICAL | X/200 lines |
+| Sessions | OK/WARN | X sessions, Y stale |
+| Bundles | OK | X bundles |
+| Engrams | OK | X engrams |
+| jitneuro.json | OK/FAIL | vX.X.X or missing |
+
+SUMMARY: X components checked, Y issues
 ```
 
-If any CRITICAL or FAIL: recommend `/health --deep` for details.
+When the agent returns, display the table. If any CRITICAL or FAIL: recommend `/health --deep` for details.
 
 ## Deep Health (`/health --deep`)
 


### PR DESCRIPTION
Bundle template still had 180 limit (should be 280). Also fixed 'Claude may skip content' -> 'Claude reads full file, shorter = fewer wasted tokens.' Soft limit is a target for reporting, not a behavior change.