### PR TITLE
feat: v1.0 team-aware architecture

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -442,6 +442,15 @@ if (Test-Path $gitignore) {
     }
 }
 
+# --- Leave onboard marker for SessionStart hook ---
+if ($Mode -eq "workspace" -and $WorkspaceRoot) {
+    $markerPath = Join-Path $Target ".needs-onboard"
+    Set-Content -Path $markerPath -Value "installed=$(Get-Date -Format 'yyyy-MM-ddTHH:mm:ss')`nmode=$Mode`nworkspace=$WorkspaceRoot"
+    Write-Host ""
+    Write-Host "  On next Claude Code session start, you will be prompted to scan" -ForegroundColor Cyan
+    Write-Host "  and onboard all repos in the workspace automatically." -ForegroundColor Cyan
+}
+
 # --- Summary ---
 Write-Host ""
 Write-Host "---" -ForegroundColor DarkGray
@@ -449,8 +458,8 @@ Write-Host "JitNeuro v$Version installed to: $Target" -ForegroundColor Green
 Write-Host ""
 Write-Host "Next steps:"
 Write-Host "  1. CLOSE AND REOPEN Claude Code (commands load at session start)" -ForegroundColor Yellow
-Write-Host "  2. Run /verify to confirm everything is working"
-Write-Host "  3. Run /onboard <repo> to set up context for your repos"
+Write-Host "  2. Claude will prompt to onboard all repos in the workspace"
+Write-Host "  3. Run /verify to confirm everything is working"
 Write-Host "  4. Create bundles for your domains in $Target\bundles\"
 Write-Host ""
 Write-Host "*** You MUST restart Claude Code for slash commands to take effect. ***" -ForegroundColor Red

--- a/install.sh
+++ b/install.sh
@@ -367,6 +367,17 @@ if [ -f "$GITIGNORE" ]; then
   fi
 fi
 
+# --- Leave onboard marker for SessionStart hook ---
+if [ "$MODE" = "workspace" ] && [ -n "$WORKSPACE_ROOT" ]; then
+  MARKER="$TARGET/.needs-onboard"
+  echo "installed=$(date -u +%Y-%m-%dT%H:%M:%S)" > "$MARKER"
+  echo "mode=$MODE" >> "$MARKER"
+  echo "workspace=$WORKSPACE_ROOT" >> "$MARKER"
+  echo ""
+  echo "  On next Claude Code session start, you will be prompted to scan"
+  echo "  and onboard all repos in the workspace automatically."
+fi
+
 # --- Summary ---
 echo ""
 echo "---"
@@ -374,8 +385,8 @@ echo "JitNeuro v$VERSION installed to: $TARGET"
 echo ""
 echo "Next steps:"
 echo "  1. CLOSE AND REOPEN Claude Code (commands load at session start)"
-echo "  2. Run /verify to confirm everything is working"
-echo "  3. Run /onboard <repo> to set up context for your repos"
+echo "  2. Claude will prompt to onboard all repos in the workspace"
+echo "  3. Run /verify to confirm everything is working"
 echo "  4. Create bundles for your domains in $TARGET/bundles/"
 echo ""
 echo "*** You MUST restart Claude Code for slash commands to take effect. ***"

--- a/templates/CLAUDE-brainstem.md
+++ b/templates/CLAUDE-brainstem.md
@@ -60,7 +60,7 @@ For routine work (research, simple fixes, docs): serial thinking is fine.
 - [Rule 3: e.g., ASCII only in all output]
 
 ## JitNeuro Mode
-<!-- Choose ONE mode. Delete the other. -->
+<!-- Choose ONE mode. Delete the others. -->
 
 <!-- OPTION A: SINGLE-REPO MODE (enterprise / isolated)
      All JitNeuro files stay inside this repo. No cross-repo access.
@@ -83,13 +83,41 @@ From any repo, Claude has full read/write access to:
 - MEMORY.md auto-memory (routing weights, project index)
 -->
 
+<!-- OPTION C: TEAM MODE (multi-developer)
+     Team knowledge in .jitneuro/ (committed). Personal state in .claude/ (gitignored).
+     Install with: /onboard --team -->
+<!--
+Team context loading cascade (in order):
+1. `.jitneuro/rules/` -- team rules (everyone, every session)
+2. `.jitneuro/engrams/` -- team project context
+3. `.jitneuro/bundles/` -- team bundles (on-demand via routing)
+4. `.jitneuro/cognition/` -- team personas, decisions
+5. `.jitneuro/context-manifest.md` -- team routing weights
+6. `.jitneuro/users/<YOU>/rules/` -- your personal repo rules
+7. `.claude/` -- your session state, local config (gitignored)
+8. `~/.claude/rules/` -- your global personal rules
+9. `~/.claude/CLAUDE.md` -- your global identity
+10. MEMORY.md -- your personal brain
+
+Team roles defined in `.jitneuro/TEAM.md` (maps git username to role).
+If TEAM.md is missing, everyone is a TeamApprover.
+-->
+
 ## Feature Discovery
 When the user expresses a need, wish, or frustration ("I wish...", "can we...", "is there a way to...", "I keep forgetting to...", "this is annoying..."), read `.claude/help.md` for matching JitNeuro capabilities before building a custom solution. JitNeuro likely already handles it. If it does, set it up. If it doesn't, build it and suggest persisting it via /learn.
 
 ## Context Loading
+<!-- Team mode: .jitneuro/ paths load first (team baseline), then .claude/ (personal) -->
+<!-- If .jitneuro/ exists, load team context first: -->
+<!-- - Team rules: `.jitneuro/rules/` -->
+<!-- - Team engrams: `.jitneuro/engrams/` -->
+<!-- - Team bundles: `.jitneuro/bundles/` (on-demand via `.jitneuro/context-manifest.md`) -->
+<!-- - Team cognition: `.jitneuro/cognition/` -->
+<!-- - Your rules: `.jitneuro/users/<YOU>/rules/` (NOT other users') -->
+<!-- Then personal context: -->
 - Bundles: `.claude/bundles/` (loaded on-demand by orchestrator)
 - Engrams: `.claude/engrams/` (per-project context, loaded per task)
-- Cognition: `.claude/cognition/personas.md` (16 expert personas, always active)
+- Cognition: `.claude/cognition/personas.md` (expert personas, always active)
 - Cognition: `.claude/cognition/owner-persona.md` (personal overlay, if exists)
 - Decisions: `.claude/cognition/decisions/` (structured decision frameworks)
 - Manifest: `.claude/context-manifest.md` (bundle index + routing)
@@ -117,6 +145,9 @@ When conversation_log is "on" in session-state.md:
 <!-- Only paths Claude needs constantly. Domain paths go in bundles. -->
 | Path | Purpose |
 |------|---------|
+| `.jitneuro/` | Team-shared knowledge (committed, if team mode) |
+| `.jitneuro/TEAM.md` | Team member list, roles, approver flags |
+| `.jitneuro/users/<YOU>/` | Your team-visible workspace |
 | `.claude/context-manifest.md` | Bundle index and routing |
 | `.claude/session-state/` | Session checkpoints (one per task) |
 | `.claude/bundles/` | Domain knowledge bundles |

--- a/templates/commands/health.md
+++ b/templates/commands/health.md
@@ -122,6 +122,17 @@ You are running a JitNeuro deep health check. Read every file listed below FROM 
 **Hook Scripts** (.claude/hooks/)
 - For each hookEvents entry, check script file exists.
 
+**Team Knowledge** (.jitneuro/) -- SKIP if .jitneuro/ does not exist
+- Check .jitneuro/TEAM.md exists and has at least one member
+- Count team rules (.jitneuro/rules/) with line counts
+- Count team engrams (.jitneuro/engrams/) with line counts
+- Count team bundles (.jitneuro/bundles/) with line counts
+- List users in .jitneuro/users/ -- check each has active-work.md
+- Check for stale lessons (pending > 7 days in any users/*/lessons.md)
+- Check .jitneuro/context-manifest.md exists and references existing bundles
+- If .jitneuro/jitneuro.json exists, validate schema matches personal jitneuro.json format
+- Flag conflicts: same rule name in .jitneuro/rules/ and .claude/rules/
+
 ## Return Format
 
 HEALTH_TABLE:

--- a/templates/commands/learn.md
+++ b/templates/commands/learn.md
@@ -4,10 +4,11 @@ Evaluate the current session for knowledge worth persisting to long-term memory.
 This is JitNeuro's backpropagation -- the system improves itself over time.
 
 ## Arguments
-- `/learn` -- full evaluation (health check + session learnings)
+- `/learn` -- full evaluation (health check + session learnings + team queue if TeamApprover)
 - `/learn q` -- quick mode: skip health check, focus on learnings only (session scan + Hub.md check still run)
+- `/learn --team` -- team-only: skip personal learnings, show team lessons queue + team health (TeamApprover only)
 
-Quick mode skips: stale session flags, archive/delete recommendations, session count warnings. Use when you know sessions are fine and just want to capture learnings fast.
+Quick mode skips: stale session flags, archive/delete recommendations, session count warnings, team queue. Use when you know sessions are fine and just want to capture learnings fast.
 
 ## When to Use
 - Before ending a session (especially productive ones)
@@ -63,11 +64,14 @@ When invoked as `/learn`:
 
 Three things happen simultaneously:
 
-**Master (needs conversation context):**
+**Master (needs conversation context, skip if `/learn --team`):**
 Scan the session for each of the 5 categories above.
 Look at: user corrections, bundle loads, manual context requests,
 new discoveries, architecture changes, decisions made.
 Produce a raw findings list (one line per finding).
+If `.jitneuro/` exists, classify each finding as TEAM or PERSONAL:
+- TEAM: conventions, quality gates, architecture decisions, testing rules (benefits all devs)
+- PERSONAL: editor preferences, workflow habits, personal shortcuts (only benefits you)
 
 **Health Agent (background, skip if `/learn q`):**
 Dispatch a background agent to run `/health` (quick mode). Agent returns the health table. Master includes health findings in the Phase 2 table if any issues found. If all healthy, no health rows in the output.
@@ -87,6 +91,33 @@ Return all findings. Do not truncate or limit -- every lesson matters.
 ```
 
 Agent A runs even in `/learn q` (quick mode) -- Hub.md lessons must always be checked. Quick mode only skips the health check (Step 0).
+
+**Team Agent (background, only if `.jitneuro/` exists AND not `/learn q`):**
+Dispatch a background agent with this prompt:
+```
+Read .jitneuro/TEAM.md to determine team members and roles.
+Get current username: git config user.name
+Determine if this user is a TeamApprover (or if TEAM.md is missing = everyone is approver).
+
+If TeamApprover:
+  Read all .jitneuro/users/*/lessons.md files.
+  Collect PENDING lessons from all users.
+  For each pending lesson:
+    - Check if .jitneuro/rules/ already has a rule covering this -> mark DUPLICATE
+    - If not duplicate, include in the team queue
+  Read .jitneuro/users/*/active-work.md timestamps for active dev status.
+  Count .jitneuro/rules/ files and check for conflicts.
+  Count .jitneuro/engrams/ files and check line counts.
+  Check for stale lessons (pending > 7 days).
+
+Return:
+  TEAM_ROLE: <role from TEAM.md or "approver (no TEAM.md)">
+  IS_APPROVER: true/false
+  TEAM_QUEUE: list of pending lessons (author, date, content)
+  TEAM_HEALTH: rules count, engram stats, active devs, stale lessons, conflicts
+```
+
+If `/learn --team`: only run Team Agent + Health Agent (skip Master scan and Agent A).
 
 ### Phase 2: Merge + Present (master only)
 
@@ -110,6 +141,40 @@ Proposed Updates:
 Present: "These are the session learnings. Approve all, or pick by number?"
 Do NOT write anything until approved.
 
+**Team output (if `.jitneuro/` exists and Team Agent returned):**
+
+For any user (TeamApprover or not), TEAM-classified findings are shown with scope:
+```
+| # | Scope | Target | Change |
+|---|-------|--------|--------|
+| 1 | TEAM (Rec) | .jitneuro/users/<you>/lessons.md | No DB mocking in tests |
+| 2 | PERSONAL | .jitneuro/users/<you>/rules/prefs.md | Prefer small PRs |
+| 3 | Learn | MEMORY.md | Add routing weight |
+```
+TEAM items write to YOUR lessons.md (staging area). PERSONAL items write to YOUR rules/.
+
+For TeamApprovers, also show:
+```
+== Team Lessons Queue ==
+| # | Author | Date | Proposed Rule |
+|---|--------|------|---------------|
+| T1 | dev03 | 2026-03-27 | No DB mocking in integration tests |
+| T2 | dev02 | 2026-03-26 | Always use UTC timestamps |
+
+Promote to team? (all / pick by # / skip)
+
+== Team Health ==
+| Component | Status | Detail |
+|-----------|--------|--------|
+| Team rules (12) | OK | No conflicts |
+| Team engrams (3) | WARN | api-context.md 160 lines (cap 150) |
+| Active devs (3) | OK | dev01: active, dev02: AFK 2h, dev03: active |
+| Stale lessons | INFO | 2 lessons >7 days without review |
+| Conflicts | OK | No file overlap between active branches |
+```
+
+Team health runs automatically when reviewing team lessons. No extra cost.
+
 ### Phase 3: Write (agent, after approval)
 
 Dispatch Agent B with the approved list:
@@ -126,6 +191,27 @@ After writing all files:
 
 Master receives confirmation. Reports what was written and where.
 
+**Team writes (if `.jitneuro/` exists):**
+
+For TEAM-scoped lessons (any user):
+- Write to `.jitneuro/users/<username>/lessons.md` under `## Pending`
+- Include date and one-line description
+
+For PERSONAL-scoped lessons (any user):
+- Write to `.jitneuro/users/<username>/rules/<topic>.md`
+
+For promotions (TeamApprover approved T# items):
+- Read the lesson from the author's `users/<author>/lessons.md`
+- Write to `.jitneuro/rules/<topic>.md` as a team rule
+- Move the lesson from `## Pending` to `## Promoted` in the author's lessons.md
+- Add: `-> .jitneuro/rules/<topic>.md` after the lesson text
+
+For rejections (TeamApprover rejects T# items):
+- Move the lesson from `## Pending` to `## Rejected` in the author's lessons.md
+- Add the rejection reason
+
+All team file writes go to Agent B alongside personal writes.
+
 ### If Nothing Found
 
 - "No learnings to persist from this session."
@@ -137,16 +223,20 @@ Master receives confirmation. Reports what was written and where.
 | 1 (scan session) | Master | Medium | Must read conversation context |
 | 1 (Hub.md + dedup) | Agent A | Low | File reads only, returns findings list |
 | 1 (health check) | Health Agent | Low | 5 file reads, returns table (skipped in -q) |
+| 1 (team queue) | Team Agent | Low | File reads only, returns queue + health (skipped in -q) |
 | 2 (merge + present) | Master | Low | Combine lists, display table |
 | 3 (write files) | Agent B | Low | File writes, returns file list |
 
-Master never reads memory/ files, Hub.md, or rules/ directly. Agents handle all file I/O.
+Master never reads memory/ files, Hub.md, rules/, or team files directly. Agents handle all file I/O.
 
 ## Important
-- Phase 1 runs in PARALLEL (master scans conversation while agent reads Hub.md)
+- Phase 1 runs in PARALLEL (master scans conversation while agents read Hub.md + team files)
 - NEVER write without user approval. Present the table first.
 - Health runs separately via /health (as agent). /learn does not run health.
 - MEMORY.md hard limit: 200 lines. Lines beyond 200 are silently truncated.
 - Bundle soft limit: 280 lines. Report if over, do NOT auto-trim. Offer to trim, default no.
 - Engram soft limit: 180 lines. Report if over, do NOT auto-trim. Offer to trim, default no.
 - This command reads and proposes. It does not modify code files, only memory/context files.
+- Team features are additive: no .jitneuro/ = solo mode, identical to v0.x behavior.
+- `/learn --team` is TeamApprover-only. If user is not a TeamApprover, say so and suggest `/learn` instead.
+- Team lesson promotion requires explicit approval per item (promote T1, promote all, skip).

--- a/templates/commands/onboard.md
+++ b/templates/commands/onboard.md
@@ -176,6 +176,110 @@ SUMMARY: [N] repos, [M] need onboarding, [X] stale
 
 Present the table. Then: "Onboard a repo: `/onboard <repo-path>`"
 
+## With `--all` flag (`/onboard --all`)
+
+Scan every repo in the workspace and onboard them all in one pass.
+Populates MEMORY.md project table and creates engrams for repos that lack them.
+This is the "day 1 bootstrap" -- a new team member runs this once and gets
+cross-repo knowledge immediately.
+
+**CRITICAL:** 20+ repos requires batched subagents. Never scan more than 8 repos per agent.
+
+### Step 1: Discover repos
+
+```bash
+# Find all git repos in workspace (1 level deep)
+ls -d [workspace]/*/.git 2>/dev/null | sed 's/\/.git$//'
+```
+
+Skip: `.claude/`, `node_modules/`, `.archive/`, `jitneuro/` (the framework itself).
+
+### Step 2: Batch and dispatch
+
+Split repos into batches of 8. For each batch, dispatch a **general-purpose** agent:
+
+```
+You are onboarding multiple repos for JitNeuro. For each repo below, analyze it
+and return a structured result. Do NOT write any files -- return data only.
+
+Repos: [list of repo paths]
+
+For each repo:
+1. Check existing state:
+   - Does [repo]/CLAUDE.md exist? Read first 5 lines for identity.
+   - Does [repo]/.claude/CLAUDE.md exist?
+   - Does an engram exist at [workspace]/.claude/engrams/[repo-name]-context.md?
+2. If no engram exists, analyze the repo:
+   - Read package.json, requirements.txt, go.mod, *.csproj, or equivalent for tech stack
+   - Read [repo]/CLAUDE.md if it exists for project identity
+   - Check git remote: git -C [repo] remote get-url origin 2>/dev/null
+   - Get last commit: git -C [repo] log -1 --format="%ci %s"
+   - List top-level directories and key files
+3. Return per-repo:
+   - name, tech_stack, status (Active/Maintenance/Deployed/Unknown), remote_url
+   - has_claude_md, has_brainstem, has_engram
+   - If no engram: proposed engram content (50-100 lines, project identity + architecture)
+
+Return format:
+STATUS: OK
+REPOS:
+  - name: RepoName
+    tech: Node/Express/TypeScript
+    status: Active Dev
+    remote: https://github.com/org/repo
+    has_claude: true
+    has_brainstem: true
+    has_engram: false
+    proposed_engram: |
+      [engram content if missing]
+```
+
+Run batches in parallel (up to 3 concurrent agents).
+
+### Step 3: Merge results and present
+
+Collect all agent results. Build two tables:
+
+**MEMORY.md Project Table (proposed):**
+```
+| Repo | Tech | Status | Engram |
+|------|------|--------|--------|
+| AIFieldSupport-API | Node/Express, Azure SQL | Active Dev | aifs-core + split engrams |
+| jitai | Next.js 16/React 19/TS | Active Dev | jitai-context.md |
+...
+```
+
+Compare against existing MEMORY.md project table:
+- NEW: repos not in MEMORY.md yet
+- UPDATE: repos where tech or status changed
+- UNCHANGED: repos that match current MEMORY.md
+- MISSING: repos in MEMORY.md but not found on disk
+
+**Engrams to create:**
+```
+| # | Repo | Lines | Path |
+|---|------|-------|------|
+| 1 | NewRepo | 65 | .claude/engrams/newrepo-context.md |
+| 2 | OtherRepo | 80 | .claude/engrams/otherrepo-context.md |
+```
+
+Present: "Found [N] repos. [M] new, [X] updated, [Y] need engrams. Approve? (all / pick by # / skip)"
+
+### Step 4: Write (after approval)
+
+Dispatch a write agent with the approved list:
+- Update MEMORY.md project table (merge, don't replace -- preserve existing notes)
+- Create missing engrams at [workspace]/.claude/engrams/[repo-name]-context.md
+- Do NOT overwrite existing engrams -- only create missing ones
+
+Report: "[N] repos indexed in MEMORY.md, [M] engrams created."
+
+### Options
+
+- `/onboard --all` -- full scan + engram creation + MEMORY.md update
+- `/onboard --all --dry-run` -- scan only, show what would change, don't write
+- `/onboard --all --refresh` -- re-analyze ALL repos (even those with engrams), propose updates
+
 ## With `--team` flag (`/onboard --team`)
 
 Creates `.jitneuro/` team folder structure in the current repo. This enables

--- a/templates/commands/onboard.md
+++ b/templates/commands/onboard.md
@@ -176,6 +176,74 @@ SUMMARY: [N] repos, [M] need onboarding, [X] stale
 
 Present the table. Then: "Onboard a repo: `/onboard <repo-path>`"
 
+## With `--team` flag (`/onboard --team`)
+
+Creates `.jitneuro/` team folder structure in the current repo. This enables
+team-aware features: shared rules, lesson promotion, active-work tracking.
+
+### Step 1: Check Prerequisites
+
+- Verify `.jitneuro/` does not already exist (if it does, report and stop)
+- Get username: `git config user.name`
+- Check if repo already has JitNeuro solo setup (.claude/CLAUDE.md etc.)
+
+### Step 2: Create .jitneuro/ Structure
+
+Copy template structure from JitNeuro templates:
+```
+.jitneuro/
+  rules/README.md
+  engrams/README.md
+  bundles/README.md
+  cognition/README.md
+  users/<username>/active-work.md  (from template, with username filled in)
+  users/README.md
+  TEAM.md                          (with current user as first TeamApprover)
+  context-manifest.md              (empty team manifest)
+  README.md
+```
+
+### Step 3: Classify Existing Knowledge (migration from v0.x)
+
+If `.claude/` has existing JitNeuro knowledge:
+a. Read `.claude/engrams/` -- engrams that describe THIS repo are team knowledge
+b. Read `.claude/bundles/` -- bundles specific to this repo are team candidates
+c. Read `.claude/cognition/` -- team personas and decisions
+d. Present classification table:
+```
+| # | File | Current Location | Recommended | Reason |
+|---|------|-----------------|-------------|--------|
+| 1 | api-context.md | .claude/engrams/ | TEAM (.jitneuro/engrams/) | Project architecture |
+| 2 | deploy.md | .claude/bundles/ | TEAM (.jitneuro/bundles/) | Shared CI/CD |
+| 3 | owner-persona.md | .claude/cognition/ | PERSONAL (stay in .claude/) | Individual identity |
+```
+e. Ask: "Move recommended items to .jitneuro/? (all / pick by # / skip)"
+f. Copy (not move) approved items to .jitneuro/ locations
+   - Original files in .claude/ are kept as personal copies
+
+### Step 4: Update .gitignore
+
+Add entries from gitignore-additions.txt if not already present.
+Verify `.jitneuro/` is NOT in .gitignore (it should be committed).
+
+### Step 5: Update CLAUDE-brainstem.md
+
+If `.claude/CLAUDE.md` exists, update the JitNeuro Mode section:
+- Comment out the current mode (A or B)
+- Uncomment Option C (Team Mode)
+
+### Step 6: Present Summary
+
+```
+Team setup complete for <repo-name>:
+  .jitneuro/ created with team structure
+  TEAM.md: <username> as TeamApprover
+  Migrated: <N> files to team knowledge
+  Next: commit .jitneuro/ and push so team members get it on pull
+```
+
+Without `--team`: existing behavior (solo onboarding with CLAUDE.md + engram).
+
 ## Important
 - **Repo analysis and workspace scan run in subagents.** File generation and writing run in master.
 - NEVER overwrite existing files without asking. Always show what would change.
@@ -183,3 +251,4 @@ Present the table. Then: "Onboard a repo: `/onboard <repo-path>`"
 - Engram creation is always safe (new file) but still ask.
 - Keep generated files minimal -- they grow organically via /learn.
 - If the repo has no package.json (e.g., PowerShell, docs-only), adapt analysis.
+- `/onboard --team` copies knowledge to .jitneuro/, never moves. Originals stay in .claude/.

--- a/templates/commands/schedule.md
+++ b/templates/commands/schedule.md
@@ -8,16 +8,22 @@ When invoked as `/schedule`:
 
 ### /schedule or /schedule list (default)
 
-1. Read `scheduledAgents` from `.claude/jitneuro.json`
-2. Check which agents are currently running (check for active background agents by name)
-3. Display status table:
+1. Read `scheduledAgents` from `.claude/jitneuro.json` (personal)
+2. If `.jitneuro/jitneuro.json` exists, also read its `scheduledAgents` (team)
+3. Merge:
+   - If only personal config exists: use personal agents only
+   - If only team config exists: use team agents only
+   - If both exist: personal overrides team by name (same name = personal wins)
+   - If neither exists: no scheduled agents
+4. Check which agents are currently running (check for active background agents by name)
+5. Display status table:
 
 ```
 Scheduled Agents:
-  #  Name        Interval  Status    Instruction         Description
-  1  autosave    30m       RUNNING   /save               Auto-save session state
-  2  hub-sync    10m       STOPPED   UPDATE_HUB          Keep TodoWrite and Hub.md current
-  3  deploy-mon  5m        DISABLED  NONE (monitoring)    Poll deploy pipeline
+  #  Name          Source    Interval  Status    Instruction         Description
+  1  housekeeper   personal 15m       RUNNING   NONE                Session housekeeper
+  2  repo-watcher  team     30m       STOPPED   NONE                Repo health watcher
+  3  deploy-mon    personal 5m        DISABLED  NONE (monitoring)   Poll deploy pipeline
 
 Tip: /schedule start|stop <name>, /schedule add|remove <name>
 ```

--- a/templates/commands/session.md
+++ b/templates/commands/session.md
@@ -245,14 +245,42 @@ BLOCKED: [count] items needing attention
    ```
    If Hub.md sync fails or is empty, WARN the user -- do not silently skip.
 
-5. **Write "my current"** (session name).
-6. Confirm with Hub.md sync status:
+5. **Team active-work.md sync** (skip if no `.jitneuro/` directory):
+
+   If `.jitneuro/` exists in the current repo:
+   a. Get username: `git config user.name`
+   b. Create `.jitneuro/users/<username>/` if it does not exist
+   c. Write `.jitneuro/users/<username>/active-work.md`:
+      ```markdown
+      # <username>
+      **Updated:** <ISO 8601 timestamp>
+      **Session:** <session-name>
+      **Branch:** <current git branch>
+      **Status:** active
+
+      ## Current Task
+      <one-line description of current work>
+
+      ## In Progress
+      <TodoWrite items as checkboxes>
+
+      ## Blockers
+      <blockers or "(none)">
+
+      ## Files Touched
+      <list of files modified this session>
+      ```
+   d. This file is committed to git -- other team members can see what you're working on.
+
+6. **Write "my current"** (session name).
+7. Confirm with Hub.md sync status:
    ```
    Saved '<name>'.
    Hub.md: [repo1] synced (3 tasks, 1 decision) | [repo2] synced (clean)
+   Team: active-work.md updated for <username>  <!-- only if .jitneuro/ exists -->
    Safe to /clear. Use `/session load <name>` to reload.
    ```
-7. Suggest: "Run `/learn` first if this session had learnings worth persisting."
+8. Suggest: "Run `/learn` first if this session had learnings worth persisting."
 
 **Size guidance:** Target 40-80 lines. Under 30 is missing pickup context. Over 120 is too verbose -- move detail into Hub.md or plan docs and reference them. The PICKUP INSTRUCTIONS section should be 15-30 lines (the most critical part).
 
@@ -361,6 +389,44 @@ Closed sessions appear in the "Closed" section on the dashboard (collapsed, grey
    ```
 7. If no items: "Session '<name>' is clear -- no blockers."
 8. **Hub.md freshness:** Check each repo's Hub.md age. If stale (>3 days or older than session checkpoint), add to BLOCKED section: "Hub.md stale for <repo> -- run /save to sync."
+
+## AFK Tracking (requires .jitneuro/)
+
+When `.jitneuro/` exists in the current repo, track autonomous work during AFK periods.
+
+### AFK Start (user signals AFK: "AFK", "brb", "stepping away", etc.)
+
+1. Get username: `git config user.name`
+2. Snapshot current state:
+   - Timestamp (ISO 8601)
+   - Session name
+   - Count of pending tasks (from TodoWrite / TaskList)
+   - List of pending task subjects
+3. Hold this snapshot in session memory (do not write yet)
+4. Continue autonomous execution per autonomous-execution rule
+
+### AFK End (user returns or session ends/saves)
+
+1. Write an AFK record to `.jitneuro/users/<username>/afk-log.md`:
+   ```markdown
+   ## <start-date> <start-time>-<end-time> (<duration>)
+   **Session:** <session-name>
+   **Tasks before AFK:** <N> pending
+   **Tasks after AFK:** <N> pending (<N> completed)
+   **Completed:**
+   - [x] <task subject>
+   **Blocked:** <blockers or "(none)">
+   **Files changed:** <count>
+   ```
+2. Append to the file (do not overwrite previous records)
+3. Create the file if it does not exist (copy header from afk-log.example.md)
+
+### Rules
+
+- AFK log is append-only. One section per AFK period, newest at top.
+- If user never signaled AFK, do not write a record.
+- If session ends without user returning, write the record with the session end time.
+- Update `.jitneuro/users/<username>/active-work.md` status to "afk" when AFK starts, "active" when user returns.
 
 ## Important
 - **Hub.md sync is MANDATORY on every save.** Do not skip it. Do not say "saved" without syncing Hub.md. This is the #1 reliability issue -- if you skip it, task state rots silently for weeks.

--- a/templates/gitignore-additions.txt
+++ b/templates/gitignore-additions.txt
@@ -6,3 +6,11 @@
 
 # Session state (ephemeral, per-machine)
 .claude/session-state/
+
+# Personal config (credentials, local settings -- never committed)
+.claude/workspace.json
+.claude/jitneuro.json
+.claude/settings.local.json
+
+# NOTE: .jitneuro/ is COMMITTED (team-shared knowledge)
+# Do NOT add .jitneuro/ to .gitignore

--- a/templates/hooks/session-start-onboard.sh
+++ b/templates/hooks/session-start-onboard.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# JitNeuro SessionStart Hook: Post-Install Onboard Prompt
+# Detects .needs-onboard marker left by install script.
+# Injects a prompt into Claude's context to offer /onboard --all.
+# Marker is deleted after Claude processes the prompt (by /onboard --all).
+#
+# stdout goes into Claude's context window as injected context.
+
+set +e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" 2>/dev/null && pwd)"
+CLAUDE_DIR="$(dirname "$SCRIPT_DIR")"
+MARKER="$CLAUDE_DIR/.needs-onboard"
+
+# Exit silently if no marker
+[ ! -f "$MARKER" ] && exit 0
+
+# Read marker content
+INSTALLED=$(grep "^installed=" "$MARKER" 2>/dev/null | cut -d= -f2)
+WORKSPACE=$(grep "^workspace=" "$MARKER" 2>/dev/null | cut -d= -f2)
+
+cat <<EOF
+[JitNeuro] Fresh install detected (installed: ${INSTALLED}).
+
+JitNeuro was just installed in workspace mode. To build your project index
+and create engrams for all repos, Claude can scan the workspace now.
+
+RECOMMENDED ACTION: Ask the user:
+"JitNeuro was just installed. Want me to scan and onboard all repos in ${WORKSPACE}?
+This will populate your project index (MEMORY.md) and create context files (engrams)
+for each repo. Takes about 2 minutes for 20 repos. (yes/no)"
+
+If the user says yes: run /onboard --all
+After /onboard --all completes (or user declines): delete the marker file at ${MARKER}
+EOF
+
+exit 0

--- a/templates/hooks/session-start-scheduled-agents.sh
+++ b/templates/hooks/session-start-scheduled-agents.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # JitNeuro SessionStart Hook: Scheduled Agents Launcher
-# Reads scheduledAgents config from jitneuro.json and injects launch instructions
-# into Claude's context. Claude (master) then spawns the timer agents.
+# Reads scheduledAgents config from both personal (.claude/jitneuro.json)
+# and team (.jitneuro/jitneuro.json) configs. Merges results.
+# Personal overrides team (same name = personal wins).
 #
 # stdout goes into Claude's context window as injected context.
 
@@ -9,99 +10,113 @@ set +e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" 2>/dev/null && pwd)"
 CLAUDE_DIR="$(dirname "$SCRIPT_DIR")"
-CONFIG="$CLAUDE_DIR/jitneuro.json"
+PERSONAL_CONFIG="$CLAUDE_DIR/jitneuro.json"
 
-# Exit silently if no config
-[ ! -f "$CONFIG" ] && exit 0
-
-# Check if scheduledAgents key exists
-if ! grep -q '"scheduledAgents"' "$CONFIG" 2>/dev/null; then
-  exit 0
+# Find repo root for team config
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+TEAM_CONFIG=""
+if [ -n "$REPO_ROOT" ] && [ -f "$REPO_ROOT/.jitneuro/jitneuro.json" ]; then
+  TEAM_CONFIG="$REPO_ROOT/.jitneuro/jitneuro.json"
 fi
 
-# Extract enabled agents using basic text parsing (no jq dependency)
-# Look for entries where "enabled": true
+# Exit silently if no config at either level
+[ ! -f "$PERSONAL_CONFIG" ] && [ -z "$TEAM_CONFIG" ] && exit 0
+
+# Function to extract agents from a config file
+# Appends to AGENTS string and increments AGENT_COUNT
+# Args: $1 = config file path, $2 = source label ("personal" or "team")
+parse_config() {
+  local CONFIG="$1"
+  local SOURCE="$2"
+
+  [ ! -f "$CONFIG" ] && return
+  grep -q '"scheduledAgents"' "$CONFIG" 2>/dev/null || return
+
+  local IN_AGENTS=false
+  local CURRENT_NAME=""
+  local CURRENT_INTERVAL=""
+  local CURRENT_INSTRUCTION=""
+  local CURRENT_PROMPT=""
+  local CURRENT_ENABLED=""
+
+  flush_agent() {
+    if [ -n "$CURRENT_NAME" ] && [ "$CURRENT_ENABLED" = "true" ]; then
+      # Check if personal override exists (personal wins over team)
+      if [ "$SOURCE" = "team" ] && echo "$PERSONAL_NAMES" | grep -qw "$CURRENT_NAME"; then
+        return
+      fi
+      AGENT_COUNT=$((AGENT_COUNT + 1))
+      AGENTS="${AGENTS}
+  - name: ${CURRENT_NAME} (${SOURCE}), interval: ${CURRENT_INTERVAL}m, instruction: ${CURRENT_INSTRUCTION}"
+      if [ -n "$CURRENT_PROMPT" ]; then
+        AGENTS="${AGENTS}, prompt: ${CURRENT_PROMPT}"
+      fi
+    fi
+  }
+
+  while IFS= read -r line; do
+    if echo "$line" | grep -q '"scheduledAgents"'; then
+      IN_AGENTS=true
+      continue
+    fi
+
+    if $IN_AGENTS && echo "$line" | grep -qE '^\s*\]'; then
+      flush_agent
+      IN_AGENTS=false
+      continue
+    fi
+
+    ! $IN_AGENTS && continue
+
+    if echo "$line" | grep -q '{'; then
+      flush_agent
+      CURRENT_NAME=""
+      CURRENT_INTERVAL=""
+      CURRENT_INSTRUCTION=""
+      CURRENT_PROMPT=""
+      CURRENT_ENABLED=""
+      continue
+    fi
+
+    val=$(echo "$line" | sed 's/.*: *"\{0,1\}\([^",}]*\)"\{0,1\}.*/\1/')
+    if echo "$line" | grep -q '"name"'; then
+      CURRENT_NAME="$val"
+    elif echo "$line" | grep -q '"interval"'; then
+      CURRENT_INTERVAL="$val"
+    elif echo "$line" | grep -q '"instruction"'; then
+      CURRENT_INSTRUCTION="$val"
+    elif echo "$line" | grep -q '"enabled"'; then
+      CURRENT_ENABLED="$val"
+    elif echo "$line" | grep -q '"prompt"'; then
+      CURRENT_PROMPT="$val"
+    fi
+  done < "$CONFIG"
+}
+
 AGENTS=""
-IN_AGENTS=false
-CURRENT_NAME=""
-CURRENT_INTERVAL=""
-CURRENT_INSTRUCTION=""
-CURRENT_PROMPT=""
-CURRENT_ENABLED=""
-CURRENT_DESC=""
 AGENT_COUNT=0
 
-while IFS= read -r line; do
-  # Detect scheduledAgents array
-  if echo "$line" | grep -q '"scheduledAgents"'; then
-    IN_AGENTS=true
-    continue
-  fi
+# Collect personal agent names first (for override detection)
+PERSONAL_NAMES=""
+if [ -f "$PERSONAL_CONFIG" ]; then
+  PERSONAL_NAMES=$(grep '"name"' "$PERSONAL_CONFIG" 2>/dev/null | sed 's/.*: *"\([^"]*\)".*/\1/')
+fi
 
-  # Exit array on closing bracket at same indent level
-  if $IN_AGENTS && echo "$line" | grep -qE '^\s*\]'; then
-    # Flush last agent
-    if [ -n "$CURRENT_NAME" ] && [ "$CURRENT_ENABLED" = "true" ]; then
-      AGENT_COUNT=$((AGENT_COUNT + 1))
-      AGENTS="${AGENTS}
-  - name: ${CURRENT_NAME}, interval: ${CURRENT_INTERVAL}m, instruction: ${CURRENT_INSTRUCTION}"
-      if [ -n "$CURRENT_PROMPT" ]; then
-        AGENTS="${AGENTS}, prompt: ${CURRENT_PROMPT}"
-      fi
-    fi
-    IN_AGENTS=false
-    continue
-  fi
-
-  if ! $IN_AGENTS; then
-    continue
-  fi
-
-  # New agent object
-  if echo "$line" | grep -q '{'; then
-    # Flush previous agent
-    if [ -n "$CURRENT_NAME" ] && [ "$CURRENT_ENABLED" = "true" ]; then
-      AGENT_COUNT=$((AGENT_COUNT + 1))
-      AGENTS="${AGENTS}
-  - name: ${CURRENT_NAME}, interval: ${CURRENT_INTERVAL}m, instruction: ${CURRENT_INSTRUCTION}"
-      if [ -n "$CURRENT_PROMPT" ]; then
-        AGENTS="${AGENTS}, prompt: ${CURRENT_PROMPT}"
-      fi
-    fi
-    CURRENT_NAME=""
-    CURRENT_INTERVAL=""
-    CURRENT_INSTRUCTION=""
-    CURRENT_PROMPT=""
-    CURRENT_ENABLED=""
-    CURRENT_DESC=""
-    continue
-  fi
-
-  # Parse fields
-  val=$(echo "$line" | sed 's/.*: *"\{0,1\}\([^",}]*\)"\{0,1\}.*/\1/')
-  if echo "$line" | grep -q '"name"'; then
-    CURRENT_NAME="$val"
-  elif echo "$line" | grep -q '"interval"'; then
-    CURRENT_INTERVAL="$val"
-  elif echo "$line" | grep -q '"instruction"'; then
-    CURRENT_INSTRUCTION="$val"
-  elif echo "$line" | grep -q '"enabled"'; then
-    CURRENT_ENABLED="$val"
-  elif echo "$line" | grep -q '"description"'; then
-    CURRENT_DESC="$val"
-  elif echo "$line" | grep -q '"prompt"'; then
-    CURRENT_PROMPT="$val"
-  fi
-
-done < "$CONFIG"
+# Parse team config first, then personal (personal overrides team by name)
+parse_config "$TEAM_CONFIG" "team"
+parse_config "$PERSONAL_CONFIG" "personal"
 
 # Nothing to launch
 if [ "$AGENT_COUNT" -eq 0 ]; then
   exit 0
 fi
 
+SOURCES=""
+[ -f "$PERSONAL_CONFIG" ] && SOURCES="personal"
+[ -n "$TEAM_CONFIG" ] && SOURCES="${SOURCES:+$SOURCES + }team"
+
 cat <<EOF
-[JitNeuro] Scheduled agents configured (${AGENT_COUNT} enabled):
+[JitNeuro] Scheduled agents configured (${AGENT_COUNT} enabled, sources: ${SOURCES}):
 ${AGENTS}
 
 Launch these now using /schedule start <name> for each, or run /schedule to see all.

--- a/templates/jitneuro.json
+++ b/templates/jitneuro.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.0",
+  "version": "1.0.0",
   "hooks": {
     "preCompactBehavior": "block",
     "autosave": true,
@@ -23,6 +23,12 @@
         "matcher": "",
         "script": "session-start-post-clear.sh",
         "timeout": 10
+      },
+      {
+        "event": "SessionStart",
+        "matcher": "",
+        "script": "session-start-onboard.sh",
+        "timeout": 5
       },
       {
         "event": "SessionStart",

--- a/templates/jitneuro/README.md
+++ b/templates/jitneuro/README.md
@@ -1,0 +1,53 @@
+# .jitneuro/ -- Team Knowledge Directory
+
+This directory contains team-shared knowledge for AI-assisted development.
+Everything here is committed to git and shared across the team.
+
+## Structure
+
+```
+.jitneuro/
+  rules/              -- Team-approved rules (loaded for everyone)
+  engrams/            -- Project context files (deep knowledge per project area)
+  bundles/            -- Domain knowledge (loaded on-demand via routing weights)
+  cognition/          -- Team personas, decision frameworks
+  users/              -- Per-developer spaces (auto-created)
+    <username>/
+      active-work.md  -- Current task, branch, blockers (auto by /save)
+      lessons.md      -- /learn output, team promotion staging
+      rules/          -- Personal repo-level rules (loaded for this user only)
+      afk-log.md      -- Autonomous execution records (auto by session tracking)
+  TEAM.md             -- Member list, roles, TeamApprover flags
+  context-manifest.md -- Team routing weights for on-demand bundle loading
+  jitneuro.json       -- Repo-level scheduled agents (optional)
+```
+
+## What Gets Loaded
+
+**Team context (everyone):**
+1. `rules/` -- all files loaded every session
+2. `engrams/` -- loaded on demand or by routing weights
+3. `bundles/` -- loaded on demand via context-manifest.md
+4. `cognition/` -- personas and decision frameworks
+5. `context-manifest.md` -- routing weight definitions
+
+**Personal context (you only):**
+- `users/<YOUR_USERNAME>/rules/` -- your repo-level preferences
+- `.claude/` (gitignored) -- session state, local config, credentials
+
+**Not loaded for you:**
+- `users/<OTHER_PEOPLE>/rules/` -- their personal preferences
+- `users/<OTHER_PEOPLE>/lessons.md` -- visible in git for review, not loaded
+
+## Progressive Enhancement
+
+| Mode | Setup | Behavior |
+|------|-------|----------|
+| Solo | No .jitneuro/ | Current v0.x behavior, nothing changes |
+| Small team | .jitneuro/ without TEAM.md | Everyone is TeamApprover |
+| Full team | .jitneuro/ with TEAM.md | Roles, lesson queue, promotion flow |
+| Enterprise | + CODEOWNERS on .jitneuro/rules/ | Branch protection on team rules |
+
+## Getting Started
+
+Run `/onboard --team` in your repo to create this structure.

--- a/templates/jitneuro/TEAM.md
+++ b/templates/jitneuro/TEAM.md
@@ -1,0 +1,32 @@
+# Team
+
+## Members
+
+| Username | Role | TeamApprover | Added |
+|----------|------|-------------|-------|
+| <!-- git config user.name --> | <!-- role --> | yes | <!-- date --> |
+
+## How It Works
+
+- **Username** matches `git config user.name` on each developer's machine
+- **Role** is informational (e.g., Sr Architect, DevOps, Jr Developer)
+- **TeamApprover** controls who can promote lessons to team rules via `/learn`
+- If this file is missing, everyone is treated as a TeamApprover (small team mode)
+
+## Roles
+
+TeamApprovers can:
+- Promote lessons from any user's `lessons.md` to `.jitneuro/rules/`
+- See team health metrics in `/learn` output
+- Review and reject proposed team rules
+
+Non-approvers can:
+- Capture lessons to their own `users/<name>/lessons.md`
+- Write personal rules to their own `users/<name>/rules/`
+- See their own lessons and personal health metrics
+
+## Adding a Team Member
+
+1. Add a row to the table above with their `git config user.name`
+2. Commit and push -- they get team context on next pull
+3. Their `users/<username>/` folder is auto-created on first `/save` or `/learn`

--- a/templates/jitneuro/bundles/README.md
+++ b/templates/jitneuro/bundles/README.md
@@ -1,0 +1,14 @@
+# Team Bundles
+
+Domain knowledge files loaded on-demand via routing weights defined in
+context-manifest.md. Bundles are heavier than rules (up to 280 lines)
+and provide deep context for specific work domains.
+
+## When to Use Bundles vs Rules
+
+- **Rules** (always loaded): Short, actionable guardrails. Under 30 lines.
+- **Bundles** (on-demand): Domain knowledge needed only for specific tasks. Up to 280 lines.
+
+## Format
+
+Same format as workspace bundles. See templates/bundles/ for examples.

--- a/templates/jitneuro/cognition/README.md
+++ b/templates/jitneuro/cognition/README.md
@@ -1,0 +1,16 @@
+# Team Cognition
+
+Shared thinking frameworks for the team: personas, decision templates,
+anti-pattern tracking.
+
+## Contents
+
+- `personas.md` -- Expert personas activated by task type
+- `decisions/` -- Decision framework templates (e.g., root-cause-analysis, technology selection)
+- `anti-patterns.md` -- Known failure modes captured from friction detection
+
+## Usage
+
+Personas activate automatically based on task context. Decision frameworks
+are loaded when making architectural or cross-cutting decisions.
+See templates/cognition/ for format examples.

--- a/templates/jitneuro/context-manifest.md
+++ b/templates/jitneuro/context-manifest.md
@@ -1,0 +1,37 @@
+# Team Context Manifest
+
+This file indexes team-shared bundles and routing weights.
+The orchestrator reads this to determine which bundles to load for a given task.
+
+## Always Load (Team Baseline)
+
+These load automatically for every team member:
+- `.jitneuro/rules/` (team rules)
+- `.jitneuro/engrams/` (team project context)
+- `.jitneuro/cognition/` (team personas, decisions)
+
+## Available Bundles
+
+| Bundle | Path | Domain | Lines | Last Updated |
+|--------|------|--------|-------|-------------|
+<!-- Add team bundles here. Keep under 280 lines each. -->
+<!-- Example:
+| deploy    | .jitneuro/bundles/deploy.md    | CI/CD, containers, environments | ~60 | 2026-01-01 |
+| api       | .jitneuro/bundles/api.md       | API design, auth, error handling | ~50 | 2026-01-01 |
+| sprint    | .jitneuro/bundles/sprint.md    | Sprint protocol, task format     | ~70 | 2026-01-01 |
+-->
+
+## Routing Weights
+
+Patterns that map task types to bundle combinations.
+Update these as the team learns which bundles co-activate:
+
+```
+- Default task         -> bundles: []  (team baseline only)
+<!-- Example routing weights:
+- Deploy tasks         -> bundles: [deploy]
+- API development      -> bundles: [api, testing]
+- Sprint execution     -> bundles: [sprint]
+- Bug investigation    -> bundles: [api, testing, deploy]
+-->
+```

--- a/templates/jitneuro/engrams/README.md
+++ b/templates/jitneuro/engrams/README.md
@@ -1,0 +1,16 @@
+# Team Engrams
+
+Project context files shared across the team. Each engram provides deep
+knowledge about a specific area of the project (architecture, data model,
+integration points, conventions).
+
+## Format
+
+Same format as personal engrams. See templates/engrams/ for examples.
+Recommended: 50-150 lines per engram, focused on what AI needs to know
+to make good decisions in that area.
+
+## Ownership
+
+Team engrams are updated via `/learn` when features are added, removed,
+or when architecture changes. Any TeamApprover can update team engrams.

--- a/templates/jitneuro/jitneuro.json
+++ b/templates/jitneuro/jitneuro.json
@@ -1,0 +1,19 @@
+{
+  "version": "1.0.0",
+  "description": "Repo-level JitNeuro config. Committed to git, shared across the team. Personal config stays in .claude/jitneuro.json (gitignored).",
+  "scheduledAgents": [
+    {
+      "name": "repo-watcher",
+      "interval": 30,
+      "enabled": false,
+      "instruction": "NONE",
+      "prompt": "Repo health watcher. Check: (1) git status for uncommitted changes older than 1 hour. (2) CI/CD status via gh run list --limit 1. (3) Branch drift: compare current branch to main (commits behind). (4) Stale PRs open > 3 days. Report only actionable findings. NONE if all clear.",
+      "description": "Team-shared repo health watcher: git status, CI/CD, branch drift, stale PRs (every 30m)"
+    }
+  ],
+  "_docs": {
+    "merging": "Repo agents (.jitneuro/jitneuro.json) run alongside personal agents (.claude/jitneuro.json). No conflicts -- names must be unique across both files.",
+    "hooks": "Hooks are NOT defined here. Hooks belong in .claude/settings.json (Anthropic namespace). This file only defines scheduledAgents for the team.",
+    "overrides": "To disable a team agent personally, add an entry with the same name and enabled: false in your .claude/jitneuro.json."
+  }
+}

--- a/templates/jitneuro/rules/README.md
+++ b/templates/jitneuro/rules/README.md
@@ -1,0 +1,20 @@
+# Team Rules
+
+Rules in this directory are loaded for every team member, every session.
+They represent team-approved conventions, guardrails, and quality standards.
+
+## How Rules Get Here
+
+1. A developer captures a lesson during work (auto or via `/learn`)
+2. The lesson is written to their `users/<name>/lessons.md` as PENDING
+3. A TeamApprover reviews pending lessons via `/learn` or `/learn --team`
+4. Approved lessons are promoted to this directory as team rules
+5. Commit + push -- the whole team gets the rule on next pull
+
+## Guidelines
+
+- One rule per file, named by topic (e.g., `testing.md`, `api-conventions.md`)
+- Keep rules concise -- under 30 lines each
+- Rules should be actionable, not aspirational
+- Include a "Why" section so developers understand the reasoning
+- Use the same format as personal rules (see templates/rules/ for examples)

--- a/templates/jitneuro/users/README.md
+++ b/templates/jitneuro/users/README.md
@@ -1,0 +1,27 @@
+# Users Directory
+
+Per-developer spaces, auto-created on first `/save` or `/learn`.
+
+## Structure
+
+```
+users/
+  <username>/           -- matches git config user.name
+    active-work.md      -- current task, branch, blockers (auto by /save)
+    lessons.md          -- /learn captures, team promotion staging
+    rules/              -- personal repo-level rules (loaded for this user only)
+    afk-log.md          -- autonomous execution tracking (auto by session)
+```
+
+## Privacy Model
+
+- Everything in `users/` is committed to git (team-visible for review)
+- Only YOUR `users/<name>/rules/` are loaded into YOUR Claude context
+- Other users' rules are visible in git but not loaded for you
+- Truly private state stays in `.claude/` (gitignored)
+
+## Auto-Creation
+
+The first time a user runs `/save` or `/learn` in a repo with `.jitneuro/`,
+their `users/<username>/` folder is created automatically using `git config user.name`.
+No manual setup required.

--- a/templates/jitneuro/users/active-work.example.md
+++ b/templates/jitneuro/users/active-work.example.md
@@ -1,0 +1,19 @@
+# username
+**Updated:** 2026-01-01T00:00:00Z
+**Session:** session-name
+**Branch:** feat/example-branch
+**Status:** active
+
+## Current Task
+Description of what you're working on right now.
+
+## In Progress
+- [ ] Current story or task
+- [x] Previously completed task
+
+## Blockers
+(none)
+
+## Files Touched
+- src/example.ts
+- docs/readme.md

--- a/templates/jitneuro/users/afk-log.example.md
+++ b/templates/jitneuro/users/afk-log.example.md
@@ -1,0 +1,11 @@
+# username AFK Log
+
+## 2026-01-01 14:00-15:30 (1h30m)
+**Session:** session-name
+**Tasks before AFK:** 6 pending
+**Tasks after AFK:** 2 pending (4 completed)
+**Completed:**
+- [x] Example completed task
+- [x] Another completed task
+**Blocked:** (none)
+**Files changed:** 4

--- a/templates/jitneuro/users/lessons.example.md
+++ b/templates/jitneuro/users/lessons.example.md
@@ -1,0 +1,10 @@
+# username lessons
+
+## Pending
+- Example lesson captured during work (2026-01-01)
+
+## Promoted
+- Example promoted lesson (2026-01-01) -> .jitneuro/rules/example.md
+
+## Rejected
+- Example rejected lesson (2026-01-01) -- Reason from TeamApprover


### PR DESCRIPTION
## Summary
- 12 new template files for `.jitneuro/` team folder structure (TEAM.md, rules/, engrams/, bundles/, cognition/, users/ with examples)
- `/learn --team` with TEAM/PERSONAL classification, TeamApprover promotion flow, and team health metrics
- `/save` writes `active-work.md` to `.jitneuro/users/<username>/` for team visibility
- AFK tracking via `afk-log.md` (append-only log of autonomous work periods)
- `/onboard --team` for v0.x migration (classifies existing knowledge as team vs personal)
- `/health` deep check includes team knowledge validation when `.jitneuro/` exists
- `/schedule` merges personal + team `jitneuro.json` configs (personal overrides by name)
- Hook updated to read both personal and team scheduled agent configs
- All team features gated on `.jitneuro/` existence -- solo mode = unchanged v0.x behavior

## Acceptance Criteria Coverage
- AC-1: .jitneuro/ folder structure -- DONE
- AC-2: Context loading cascade -- DONE (CLAUDE-brainstem.md Option C)
- AC-3: /learn with team support -- DONE
- AC-4: active-work.md auto-sync -- DONE
- AC-5: afk-log.md tracking -- DONE
- AC-6: TEAM.md and roles -- DONE
- AC-7: Solo mode backward compatibility -- VERIFIED
- AC-8: Team health in /learn --team -- DONE
- AC-9: Repo-specific watcher agent -- DONE

## Test plan
- [ ] Verify templates/jitneuro/ has complete folder structure (11 files)
- [ ] Verify session.md save step 5 has .jitneuro/ guard clause
- [ ] Verify learn.md --team flag dispatches Team Agent only when .jitneuro/ exists
- [ ] Verify onboard.md --team creates structure and classifies knowledge
- [ ] Verify hook reads both personal and team configs
- [ ] Verify all modified commands work without .jitneuro/ (solo mode)