### PR TITLE
feat: session hook optimizations + hub guardrail

### DIFF
--- a/docs/claude-code-feature-requests.md
+++ b/docs/claude-code-feature-requests.md
@@ -1,0 +1,82 @@
+# Claude Code Feature Requests (Created / Upvoted)
+**Last Updated:** 2026-03-28
+
+All items on this list have been upvoted. Please do the same.
+
+## Autonomous Execution
+
+| # | Link | Description | Why it matters |
+|---|------|-------------|----------------|
+| 1 | [#33783](https://github.com/anthropics/claude-code/issues/33783) | /never-stop mode for autonomous execution | Core pain point -- Claude stops between tasks |
+| 2 | [#37386](https://github.com/anthropics/claude-code/issues/37386) | Claude walks back correct, user-approved fixes based on self-doubt | Interrupts approved autonomous work |
+
+## Rules Compliance
+
+| # | Link | Description | Why it matters |
+|---|------|-------------|----------------|
+| 3 | [#28158](https://github.com/anthropics/claude-code/issues/28158) | CLAUDE.md instructions systematically ignored / suspected model substitution | Rules defined, acknowledged, then violated |
+| 4 | [#8059](https://github.com/anthropics/claude-code/issues/8059) | Claude violates rules clearly defined in CLAUDE.md (by its own admission) | LOCKED -- cannot upvote |
+| 5 | [#12068](https://github.com/anthropics/claude-code/issues/12068) | CLAUDE.md "no auto-commit" rule violated on session resume | Rules lost after context summary/compaction |
+
+## Hooks & Session
+
+| # | Link | Description | Why it matters |
+|---|------|-------------|----------------|
+| 6 | [#25642](https://github.com/anthropics/claude-code/issues/25642) | Expose session ID as $CLAUDE_SESSION_ID env var | Eliminates JSON parsing in heartbeat hook (we coded around limitation) |
+| 7 | [#38390](https://github.com/anthropics/claude-code/issues/38390) | Expose session_id to conversation context | Session ID visible inside conversation, not just hooks |
+| 8 | [#28221](https://github.com/anthropics/claude-code/issues/28221) | PostTask hook -- fire when background agent completes | Needed for deploy monitoring + scheduled agent re-spawn |
+| 9 | [#34431](https://github.com/anthropics/claude-code/issues/34431) | SessionStart:resume hook payload missing 'cwd' field | Hook payload completeness |
+
+## Context & Compaction
+
+| # | Link | Description | Why it matters |
+|---|------|-------------|----------------|
+| 10 | [#9796](https://github.com/anthropics/claude-code/issues/9796) | Context compaction erases .claude/project-context.md instructions | CLAUDE.md rules lost after compaction (we coded around limitation) |
+| 11 | [#33088](https://github.com/anthropics/claude-code/issues/33088) | PreCompact hook + background compaction | Would enable auto-save before context loss |
+| 12 | [#32946](https://github.com/anthropics/claude-code/issues/32946) | Rolling asynchronous compaction | Prevents losing work mid-task |
+| 13 | [#17428](https://github.com/anthropics/claude-code/issues/17428) | Enhanced /compact with file-backed summaries | Aligns with our /save checkpoint pattern |
+| 14 | [#28389](https://github.com/anthropics/claude-code/issues/28389) | Effective usable context window reduced by infrastructure overhead | Real constraint on CLAUDE.md + rules/ size |
+
+## Task Management
+
+| # | Link | Description | Why it matters |
+|---|------|-------------|----------------|
+| 15 | [#31103](https://github.com/anthropics/claude-code/issues/31103) | TodoWrite/TaskCreate unrecognized for custom agents | Blocks multi-agent task delegation via Agent SDK |
+| 16 | [#32347](https://github.com/anthropics/claude-code/issues/32347) | TaskCreate batch calls display in random order | Task ordering matters for sprint execution |
+| 17 | [#23874](https://github.com/anthropics/claude-code/issues/23874) | Task tools disabled in VS Code (isTTY check) | Blocks TaskCreate in VS Code extension |
+
+## Background Agents
+
+| # | Link | Description | Why it matters |
+|---|------|-------------|----------------|
+| 18 | [#38859](https://github.com/anthropics/claude-code/issues/38859) | Background agents cannot get Bash permissions | Blocks watcher agents from executing bash autonomously |
+| 19 | [#36323](https://github.com/anthropics/claude-code/issues/36323) | Background agents lose edits when parent switches branches | Branch safety for background agents during sprints |
+| 20 | [#39530](https://github.com/anthropics/claude-code/issues/39530) | Stop hook blocks unrelated parallel sessions | Session isolation for parallel agents (ralph-tui) |
+
+## Memory
+
+| # | Link | Description | Why it matters |
+|---|------|-------------|----------------|
+| 21 | [#31294](https://github.com/anthropics/claude-code/issues/31294) | Subagents never create or update MEMORY.md | Blocks multi-agent /learn pattern |
+| 22 | [#38536](https://github.com/anthropics/claude-code/issues/38536) | Shared team memory for Claude Code | Team-level shared memory for multi-session orchestration |
+| 23 | [#38519](https://github.com/anthropics/claude-code/issues/38519) | Project-scoped memory in repository for cross-device sync | In-repo memory for team portability |
+| 24 | [#36045](https://github.com/anthropics/claude-code/issues/36045) | Branch-aware auto-memory | Branch-scoped memory for feature branch isolation |
+
+## Enterprise & Governance
+
+| # | Link | Description | Why it matters |
+|---|------|-------------|----------------|
+| 25 | [#34209](https://github.com/anthropics/claude-code/issues/34209) | Allow projects to exclude inherited .claude/rules/ from parent dirs | Enterprise rule scoping |
+| 26 | [#20880](https://github.com/anthropics/claude-code/issues/20880) | Exclude parent CLAUDE.md from auto-loading in subdirectories | Parent/child rule inheritance control |
+| 27 | [#39882](https://github.com/anthropics/claude-code/issues/39882) | PreApiCall/PostApiCall hooks for secret exfiltration prevention | Enterprise security -- prevent secrets leaking to API |
+| 28 | [#24185](https://github.com/anthropics/claude-code/issues/24185) | Claude reads .env files and hardcodes secrets into inline scripts | Security vulnerability -- secrets in code |
+| 29 | [#24317](https://github.com/anthropics/claude-code/issues/24317) | OAuth refresh token race condition with concurrent sessions | Multi-session auth stability (28 upvotes) |
+| 30 | [#25148](https://github.com/anthropics/claude-code/issues/25148) | Enable Agent Teams on all plans | Team agent features shouldn't be plan-gated |
+| 31 | [#18550](https://github.com/anthropics/claude-code/issues/18550) | Automatic cost tracking and reporting | Enterprise cost visibility |
+| 32 | [#21051](https://github.com/anthropics/claude-code/issues/21051) | Display message timestamps in CLI | Audit trail / session timing visibility |
+
+## Bugs
+
+| # | Link | Description | Status |
+|---|------|-------------|--------|
+| 33 | [#4686](https://github.com/anthropics/claude-code/issues/4686) | Copy/paste extra formatting chars | LOCKED |

--- a/docs/commands-reference.md
+++ b/docs/commands-reference.md
@@ -19,6 +19,7 @@ Manage the current session. Default (no subcommand) shows current session status
   - `dashboard` -- current session's blockers and NEEDS OWNER items
 
 - **Tracking:** Active session resolved from `heartbeats/<session-id>` in `.claude/session-state/`. The session-id is injected into Claude's context by the SessionStart hook. The heartbeat file's content holds the JitNeuro session name; its mtime is the last heartbeat timestamp.
+- **Watcher agent:** Both `new` and `load` automatically spawn scheduled agents (watcher agents) configured in the project's config file. These agents run in the background and periodically interrupt master for housekeeping (autosave, hub-sync, resume-tasks). If no agents are configured, a warning is displayed. The `session-guardrail` rule provides a backstop: if a session becomes active without going through `new` or `load` (e.g., context reset), the guardrail spawns the watcher.
 - **Tag rule:** Every response ends with `[session: <name> | DIV: <MODE>]`
 
 Examples:
@@ -264,8 +265,9 @@ Manage scheduled agents -- background timer agents that periodically interrupt m
   - `remove <name>` -- remove from config
 
 - **Default agents (ship with jitneuro):**
-  - `autosave` (30m) -- runs /save every 30 minutes
-  - `hub-sync` (10m) -- checks TodoWrite vs Hub.md drift every 10 minutes
+  - `housekeeper` (15m) -- unified agent: task enforcement, hub sync, autosave, heartbeat check, pending questions. Replaces legacy autosave and hub-sync agents.
+
+- **Auto-spawn:** Watcher agents are automatically spawned when a session is created (`/session new`) or loaded (`/session load`). The `session-guardrail` rule provides a backstop for sessions that become active through other paths (context reset, fresh start).
 
 - **Architecture:** Timer agent pattern. Agent sleeps for interval, returns instruction, dies. Master executes instruction and re-spawns. Agent context never grows. Runs indefinitely.
 

--- a/templates/commands/session.md
+++ b/templates/commands/session.md
@@ -82,7 +82,7 @@ Next steps:
 BLOCKED: [count] items needing attention
 ```
 
-7. **Hub.md freshness check:** For each repo in the session, check `<repo>/.HUB/Hub-*.md`:
+7. **Hub.md freshness check:** For each repo in the session, check `<repo>/.HUB/Hub.md`:
    - If Hub.md exists: show "Last Updated" date. If older than session checkpoint, flag: "Hub.md STALE -- last updated <date>, session saved <date>. Run /save to sync."
    - If Hub.md missing and session has tasks: flag: "No Hub.md -- task state is volatile only."
 8. Flag issues: repos on main with dirty files, unpushed commits, behind remote
@@ -119,6 +119,7 @@ BLOCKED: [count] items needing attention
    ```
 4. **Write "my current"** (session name).
 5. Confirm: "Session '<name>' created."
+6. **Spawn scheduled agents (mandatory):** Same process as `/session load` step 9. Read the project's config for `scheduledAgents`, spawn enabled agents, display confirmation or warning. New sessions need the interrupt mechanism from the start.
 
 ### session save <name>
 
@@ -217,7 +218,7 @@ BLOCKED: [count] items needing attention
 
    For each repo involved in this session:
    a. Check if `<repo>/.HUB/` exists. If not, create it.
-   b. Find or create `Hub-<NN>.md` (use next available number if creating).
+   b. Find or create `Hub.md` (ONE file per .HUB/ folder -- never versioned, never create Hub-01.md or Hub-v2.md).
    c. Find or create a **session section** using the session name as the heading:
       ```markdown
       ## <session-name> (sync)          <-- session name + brief focus area
@@ -286,6 +287,13 @@ BLOCKED: [count] items needing attention
    ```
 
 8. If session is stale (>7 days), mention it and ask if still relevant
+
+9. **Spawn scheduled agents (mandatory):**
+   a. Read the project's config file for `scheduledAgents`.
+   b. If config is missing or has no `scheduledAgents` key: display `** WARNING: No scheduled agents configured. Session has no watcher. **`
+   c. If all agents have `enabled: false`: display `** WARNING: All scheduled agents disabled. Session has no watcher. **`
+   d. For each agent where `enabled: true`: spawn as background timer agent with configured interval and prompt. Include in the agent prompt: `Your FIRST return to master must be the message: ** Watcher agent [name] running **` -- nothing else on that first return. Master displays this to the user as confirmation.
+   e. After spawning, display: `** Watcher agent [name] spawned -- awaiting first check-in **`
 
 ### session pulse
 

--- a/templates/hooks/branch-protection.sh
+++ b/templates/hooks/branch-protection.sh
@@ -7,6 +7,9 @@
 
 set +e  # never abort on errors
 
+# Early exit: skip if not in a git repo (avoids unnecessary git calls)
+git rev-parse --git-dir >/dev/null 2>&1 || exit 0
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" 2>/dev/null && pwd)"
 CONFIG="$(dirname "$SCRIPT_DIR")/jitneuro.json"
 LOG="/tmp/jitneuro-branch-protection.log"

--- a/templates/hooks/heartbeat.sh
+++ b/templates/hooks/heartbeat.sh
@@ -5,13 +5,26 @@
 # No stdout. Exit 0 always.
 
 set +e
-INPUT=""
-if command -v timeout >/dev/null 2>&1; then
-  INPUT=$(timeout 2 cat 2>/dev/null || true)
-else
-  while IFS= read -r -t 2 line; do INPUT="${INPUT}${line}"; done
+
+# Fast path: use env var set by SessionStart (zero parsing)
+SID="$CLAUDE_SESSION_ID"
+
+# Fallback: parse JSON from stdin (first session before env var is set)
+if [ -z "$SID" ]; then
+  INPUT=""
+  if command -v timeout >/dev/null 2>&1; then
+    INPUT=$(timeout 2 cat 2>/dev/null || true)
+  else
+    while IFS= read -r -t 2 line; do INPUT="${INPUT}${line}"; done
+  fi
+  # Bash parameter expansion instead of grep/sed pipeline
+  tmp="${INPUT#*\"session_id\"}"
+  tmp="${tmp#*\"}"
+  SID="${tmp%%\"*}"
+  # Validate: session IDs are UUID-like, reject garbage
+  case "$SID" in *[!a-f0-9-]*) SID="" ;; esac
 fi
-SID=$(echo "$INPUT" | grep -o '"session_id"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | grep -o '"[^"]*"$' | tr -d '"')
+
 [ -z "$SID" ] && exit 0
 d="${CLAUDE_PROJECT_DIR:-$HOME}/.claude/session-state/heartbeats"
 mkdir -p "$d" 2>/dev/null

--- a/templates/hooks/session-start-write-id.sh
+++ b/templates/hooks/session-start-write-id.sh
@@ -40,6 +40,12 @@ if [ -n "$SESSION_ID" ]; then
   printf '%s' "$SESSION_NAME" > "$HEARTBEATS_DIR/$SESSION_ID" 2>/dev/null
 
   echo "[JitNeuro] session-id: $SESSION_ID"
+
+  # Export session ID as env var for downstream hooks (heartbeat, etc.)
+  # CLAUDE_ENV_FILE is only available to SessionStart hooks
+  if [ -n "$CLAUDE_ENV_FILE" ]; then
+    echo "export CLAUDE_SESSION_ID=$SESSION_ID" >> "$CLAUDE_ENV_FILE" 2>/dev/null
+  fi
 fi
 
 exit 0

--- a/templates/rules/hub-guardrail.md
+++ b/templates/rules/hub-guardrail.md
@@ -1,0 +1,15 @@
+# Hub.md Guardrail
+
+## Rules
+1. **Never version Hub.md.** Hub.md is the active task list -- updated in place, never copied to Hub-01.md, Hub-v030.md, or any variant. There is exactly ONE Hub.md per .HUB/ folder.
+2. **Never delete Hub.md.** It is the durable record of task state. If tasks are complete, mark them done -- do not remove the file.
+3. **Hub.md is local only.** .HUB/ is gitignored. Future tasks for public repos belong in issue trackers or feature request files, not Hub.md.
+
+## Why
+Hub.md is the single source of truth for session task state. Versioning it fragments the task list across files, causing tasks to be lost and work to be duplicated. Deleting it destroys the only durable record of in-progress work -- task lists and session memory are volatile.
+
+## What violates this guardrail
+- Creating Hub-01.md, Hub-v2.md, or any numbered/versioned variant
+- Applying file-versioning rules to Hub.md (Hub.md is explicitly exempt)
+- Deleting Hub.md or replacing it with a new file
+- Moving Hub.md to .archive/

--- a/templates/rules/session-guardrail.md
+++ b/templates/rules/session-guardrail.md
@@ -1,5 +1,19 @@
 # Session Guardrail
 
-At the start of every conversation, validate `.claude/session-state/.current` points to an existing file.
-If `.current` is empty, missing, or points to a non-existent/archived session, auto-create a new session immediately based on the first request before doing any other work.
+At the start of every conversation, validate `.claude/session-state/heartbeats/<session-id>` resolves to an active session name.
+If the heartbeat file is empty, missing, or points to a non-existent/archived session, auto-create a new session immediately based on the first request before doing any other work.
 Claude NEVER operates under `[session: none]`. Every response requires an active session.
+
+## Scheduled Agent Check (mandatory)
+
+After the session is active (loaded or created), check whether scheduled agents are running. If no scheduled agents have been spawned this conversation, read the project's config for `scheduledAgents` and spawn any where `enabled: true` as background timer agents.
+
+This is the backstop -- `/session load` and `/session new` both spawn scheduled agents as part of their flow, but if a session becomes active through any other path (context reset, fresh start without /load), this guardrail catches it.
+
+**Visibility is mandatory:**
+- On successful spawn: display `** Watcher agent [name] spawned -- awaiting first check-in **`
+- On first return from watcher: the agent's first return is `** Watcher agent [name] running **` -- master displays this to the user as confirmation
+- If config missing or no enabled agents: display `** WARNING: No watcher agent configured. Session has no interrupt mechanism. **`
+- If spawn fails: display `** ERROR: Watcher agent failed to spawn. **` and retry once
+
+Sessions without timer agents have no interrupt mechanism. The watcher agent is what enforces autosave, hub-sync, resume-tasks, and pending question surfacing. Without it, autonomous execution has no safety net. Invisible failure is the worst failure -- always surface watcher status.


### PR DESCRIPTION
## Summary
- Heartbeat hook: CLAUDE_SESSION_ID env var fast path eliminates JSON parsing on every tool call
- SessionStart exports session ID via CLAUDE_ENV_FILE for all downstream hooks
- Branch protection early exit when not in a git repo
- Session command: mandatory watcher agent spawn on new/load, fixed Hub versioning bug
- Session guardrail: scheduled agent backstop with visibility rules
- New hub-guardrail rule: Hub.md is never versioned, never deleted
- Commands reference: documented watcher agent auto-spawn and housekeeper

## Root cause fix
The session save command (step 4b) literally instructed Claude to "create Hub-<NN>.md (use next available number)" -- this was the root cause of Hub.md being versioned into Hub-01.md, Hub-v020.md, Hub-v030.md. Fixed to enforce one Hub.md per .HUB/ folder.

## Test plan
- [ ] Verify heartbeat.sh uses env var on second+ tool call (no JSON parse)
- [ ] Verify branch-protection.sh exits cleanly outside git repos
- [ ] Verify /session new spawns watcher agent with visible confirmation
- [ ] Verify /session load spawns watcher agent with visible confirmation
- [ ] Verify session-guardrail backstop spawns watcher if no agents running