### PR TITLE
chore: gitignore PRDs/ and docs/debug.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,12 @@ Thumbs.db
 # Internal project notes (per-machine, not shared)
 .HUB/
 
+# Local planning docs (not shipped)
+PRDs/
+
+# Debug logs
+docs/debug.log
+
 # Ralph task runner runtime files (optional -- only needed if using ralph-tui)
 .ralph-tui/iterations/
 .ralph-tui/reports/


### PR DESCRIPTION
## Summary
- Add PRDs/ to .gitignore (local planning docs, not shipped)
- Add docs/debug.log to .gitignore