### PR TITLE
Add DBA routing to paperclip-dispatch

### DIFF
--- a/.github/workflows/paperclip-dispatch.yml
+++ b/.github/workflows/paperclip-dispatch.yml
@@ -13,7 +13,7 @@ jobs:
     if: >-
       github.event.action == 'opened' ||
       (github.event.action == 'labeled' && contains(
-        fromJson('["backend","frontend","security","architecture","qa","devops","review","sre","compliance"]'),
+        fromJson('["backend","frontend","security","architecture","qa","devops","review","sre","compliance","dba-review","schema-change","migration","dba-approved","dba-blocked"]'),
         github.event.label.name
       ))
     steps:
@@ -68,6 +68,7 @@ jobs:
               review)            AGENT="Sys Code Reviewer" ;;
               sre)               AGENT="Sys SRE" ;;
               compliance)        AGENT="Sys Compliance" ;;
+              dba-review|schema-change|migration) AGENT="Database Administrator" ;;
             esac
           done
 


### PR DESCRIPTION
Adds DBA label routing (dba-review, schema-change, migration) to the Paperclip dispatch workflow. Infrastructure change only -- no code impact.