### PR TITLE
feat(templates): Step 2 -- notify-jit-knowledge workflow + url-resolver example

### DIFF
--- a/templates/.github/workflows/notify-jit-knowledge.yml
+++ b/templates/.github/workflows/notify-jit-knowledge.yml
@@ -1,0 +1,43 @@
+name: Notify jit-knowledge of engram/bundle/rules change
+
+# Installed in every repo subscribed to jit-knowledge per
+# https://github.com/dstolts/jit-knowledge/blob/main/sync/subscribed-repos.json
+#
+# Fires when content under .jitneuro/ changes on the default branch (main or uat).
+# Posts a repository_dispatch event to jit-knowledge so refresh-index.yml regenerates
+# the Routing Index in INDEX.md.
+#
+# Requires repo secret JIT_KNOWLEDGE_DISPATCH_TOKEN -- fine-grained PAT scoped to
+# Contents:write on dstolts/jit-knowledge. See
+# https://github.com/dstolts/jit-knowledge/blob/main/projects/dispatch-token-setup.md
+
+on:
+  push:
+    branches: ['$default-branch']
+    paths:
+      - '.jitneuro/engrams/**'
+      - '.jitneuro/bundles/**'
+      - '.jitneuro/rules/**'
+      - '.jitneuro/cognition/**'
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch knowledge-changed to jit-knowledge
+        env:
+          GH_TOKEN: ${{ secrets.JIT_KNOWLEDGE_DISPATCH_TOKEN }}
+        run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "ERROR: JIT_KNOWLEDGE_DISPATCH_TOKEN secret not set. Distribute via projects/dispatch-token-setup.md loop."
+            exit 1
+          fi
+          gh api -X POST repos/dstolts/jit-knowledge/dispatches \
+            -f event_type=knowledge-changed \
+            -f client_payload[repo]=${{ github.repository }} \
+            -f client_payload[branch]=${{ github.ref_name }} \
+            -f client_payload[sha]=${{ github.sha }} \
+            -f client_payload[trigger]=push

--- a/templates/url-resolver.example.md
+++ b/templates/url-resolver.example.md
@@ -1,0 +1,49 @@
+# URL Resolver (per-machine)
+
+**Location:** `~/.claude/url-resolver.md` (one per machine; NOT committed to any canonical repo)
+
+This file maps GitHub repo URLs to local filesystem paths so that consumers reading `jit-knowledge/INDEX.md` (which uses GitHub URLs as canonical sources) can resolve them to local clones without network round-trips.
+
+## How loaders use it
+
+1. Read INDEX.md row -> get GitHub URL (e.g., `https://github.com/dstolts/dash-api/blob/uat/.jitneuro/engrams/context.md`)
+2. Extract repo URL prefix: `https://github.com/dstolts/dash-api`
+3. Lookup in table below -> get local path: `D:/Code/dash-api`
+4. Construct full local path: `D:/Code/dash-api/.jitneuro/engrams/context.md`
+5. Read from disk
+
+**Fallback when no entry:** fetch `https://raw.githubusercontent.com/<owner>/<repo>/<branch>/<path>` directly (read-only).
+
+## Resolver table
+
+| Repo URL | Local Path |
+|---|---|
+| https://github.com/dstolts/jit-knowledge | C:/Users/dstolts/Code/jit-knowledge |
+| https://github.com/dstolts/jitai-openclaw | C:/Users/dstolts/Code/jitai-openclaw |
+| https://github.com/dstolts/dash-api | C:/Users/dstolts/Code/dash-api |
+| https://github.com/dstolts/dash | (TBD -- add when cloned locally) |
+| https://github.com/dstolts/jitneuro | D:/Code/jitneuro |
+| https://github.com/dstolts/jitai-www | D:/Code/jitai-www |
+| https://github.com/dstolts/scanner-platform | D:/Code/scanner-platform |
+| https://github.com/dstolts/AIFieldSupport-App | D:/Code/AIFS |
+| https://github.com/dstolts/jITSecure | D:/Code/jITSecure |
+| https://github.com/dstolts/CoWork | D:/Code/CoWork |
+| https://github.com/dstolts/agent-showcase | D:/Code/agent-showcase |
+| https://github.com/dstolts/jitai-api | D:/Code/jitai-api |
+| https://github.com/dstolts/Paperclip | D:/Code/Paperclip |
+| https://github.com/dstolts/TaskManager | D:/Code/Tools/TaskManager |
+
+**Note:** On DEVINFRAVM the `D:/Code/` and `C:/Users/dstolts/Code/` paths are the same physical location (verified by sentinel file test). Pick whichever style you prefer.
+
+## Setup on a new machine
+
+1. Copy this file to `~/.claude/url-resolver.md` (PowerShell: `~` is `$env:USERPROFILE`)
+2. Edit the table to match your local clone locations
+3. For repos you don't have cloned: leave the row out, loaders fall back to raw.githubusercontent.com fetch
+4. Re-edit whenever you clone a new repo or move an existing one
+
+## Conventions
+
+- Use forward slashes (`/`) regardless of OS for portability with Bash tools
+- Keep entries alphabetical by repo URL for diff readability
+- Avoid mapping the same repo URL to multiple paths (loaders pick the first match)


### PR DESCRIPTION
## Summary
Companion to jit-knowledge PR #33. Ships the two scaffolding artifacts subscribed repos need.

### New templates
- \`templates/.github/workflows/notify-jit-knowledge.yml\` -- fires on push to default branch when \`.jitneuro/{engrams,bundles,rules,cognition}/**\` changes; posts \`repository_dispatch\` to dstolts/jit-knowledge
- \`templates/url-resolver.example.md\` -- per-machine GitHub URL -> local path map; loaders use this after reading INDEX

## Why
Plan v2.1 server-side propagation needs two cooperating workflows. Source-side (this PR) + sink-side (jit-knowledge PR #33).

## Risk
Templates only. No live workflow runs from this PR.

## Test plan
- [x] YAML syntactically valid
- [x] \`\$default-branch\` trigger pattern (GitHub-supported)
- [x] JIT_KNOWLEDGE_DISPATCH_TOKEN already distributed to 7 repos
- [ ] First install on dash-api (Step 3) validates end-to-end loop

## Follow-ups
- Step 3 pilot: install notify-jit-knowledge.yml in dash-api/.github/workflows/
- Hub.md task #14: \`.knowledge/\` placeholder structure

## Related
- jit-knowledge PR #33
- plan v2.1