### PR TITLE
feat: subscribe jitneuro to jit-knowledge canonical sync

### DIFF
--- a/.github/workflows/notify-jit-knowledge.yml
+++ b/.github/workflows/notify-jit-knowledge.yml
@@ -1,0 +1,43 @@
+name: Notify jit-knowledge of engram/bundle/rules change
+
+# Installed in every repo subscribed to jit-knowledge per
+# https://github.com/dstolts/jit-knowledge/blob/main/sync/subscribed-repos.json
+#
+# Fires when content under .jitneuro/ changes on the default branch (main or uat).
+# Posts a repository_dispatch event to jit-knowledge so refresh-index.yml regenerates
+# the Routing Index in INDEX.md.
+#
+# Requires repo secret JITAI_OPENCLAW_PROD -- fine-grained PAT scoped to
+# Contents:write on dstolts/jit-knowledge. See
+# https://github.com/dstolts/jit-knowledge/blob/main/projects/dispatch-token-setup.md
+
+on:
+  push:
+    branches: ['$default-branch']
+    paths:
+      - '.jitneuro/engrams/**'
+      - '.jitneuro/bundles/**'
+      - '.jitneuro/rules/**'
+      - '.jitneuro/cognition/**'
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch knowledge-changed to jit-knowledge
+        env:
+          GH_TOKEN: ${{ secrets.JITAI_OPENCLAW_PROD }}
+        run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "ERROR: JITAI_OPENCLAW_PROD secret not set. Distribute via projects/dispatch-token-setup.md loop."
+            exit 1
+          fi
+          gh api -X POST repos/dstolts/jit-knowledge/dispatches \
+            -f event_type=knowledge-changed \
+            -f client_payload[repo]=${{ github.repository }} \
+            -f client_payload[branch]=${{ github.ref_name }} \
+            -f client_payload[sha]=${{ github.sha }} \
+            -f client_payload[trigger]=push

--- a/.jitneuro/engrams/context.md
+++ b/.jitneuro/engrams/context.md
@@ -1,0 +1,183 @@
+---
+name: jitneuro
+type: engram
+domains:
+  - jitneuro
+  - jitneuro.ai
+  - DOE
+  - framework
+  - JitNeuro
+  - directive-orchestration-execution
+  - templates
+  - cognition
+  - bundles-system
+  - skills
+  - hooks
+  - slash-commands
+  - open-source-framework
+status: production
+version: 2026-05-11
+repo: dstolts/jitneuro
+last-verified: 2026-05-11
+owner: dstolts
+---
+
+# jitneuro Engram
+
+**Status:** Production
+**Last verified:** 2026-05-11
+**Migrated from:** `C:/Users/dstolts/Code/.claude/engrams/jitneuro-context.md` (Step 4 jit-knowledge canonicalization 2026-05-11).
+
+## Identity
+
+JitNeuro is an **open-source AI engineering framework for Claude Code**. It provides structured behaviors (skills, rules, hooks, cognition) that make AI assistants reliable, security-aware, and production-grade.
+
+Purpose: production tool AND enterprise thought leadership. Never optimize for just Owner's team alone -- every design decision must work for any adopter.
+
+- **GitHub:** `dstolts/jitneuro`
+- **Local path:** `C:/Users/dstolts/Code/jitneuro`
+- **Domains:** jitneuro.ai (primary), jitneuro.com (redirects to .ai)
+- **Current version target:** v0.4.5
+
+## Architecture
+
+### Skills-First Pivot (2026-03-30)
+
+JitNeuro pivoted from "monolithic framework you adopt wholesale" to "composable skills you install individually" using Anthropic's official SKILL.md standard (Dec 2025).
+
+- `.claude/skills/<skill-name>/SKILL.md` replaces `.claude/commands/` as primary behavior mechanism
+- Skills use SKILL.md with YAML frontmatter (progressive disclosure, ~100 tokens at startup)
+- Commands still work but are legacy -- skills take precedence
+- Install all skills by default; users remove what they don't want
+
+### v0.4.5 Scope (ships)
+
+- Skills architecture: `.claude/skills/<skill-name>/SKILL.md`
+- Core skills: `strategy`, `divergent`, `rca`, `learn`, `session`, `health`, `review`, `gap`
+- Always-on rules: truth-over-speed, scope-guard, trust zones, friction detection, verify-before-presenting
+- Cognition layer: personas.md, anti-patterns.md, decisions/
+- Hooks: PostToolUse heartbeat, pre-commit branch protection
+- Bundles and engrams (personal mode in v0.4.5)
+- Simplified install via `install.sh` / `install.ps1`
+
+### Deferred to v2
+
+- `.jitneuro/` shared team folders, TEAM.md, per-user tracking
+- `/learn --team` promotion workflow
+- machineName, bundle-map.json
+- Enterprise docs and dashboard
+- External cron launcher
+
+## Key Paths
+
+| Path | Purpose |
+|------|---------|
+| `templates/commands/` | Slash command templates (16 commands + 5 shortcuts + test-tools) |
+| `templates/hooks/` | Hook script templates (4 hooks) |
+| `templates/engrams/` | Engram templates + examples |
+| `templates/rules/` | Path-scoped rule templates |
+| `templates/.github/workflows/` | GH Actions templates (incl. notify-jit-knowledge.yml) |
+| `templates/CLAUDE-brainstem.md` | CLAUDE.md template for new repos |
+| `docs/` | Setup guide, commands reference, hooks guide |
+| `install.sh` / `install.ps1` | Installation scripts (workspace/project/user modes) |
+
+## Core Components
+
+### Skills (`.claude/skills/`)
+
+| Skill | Purpose |
+|-------|---------|
+| strategy | 3-phase gated workflow: plan -> approve -> execute |
+| divergent | FRAME -> DIVERGE -> EVALUATE -> CONVERGE -> EXECUTE reasoning |
+| rca | Root cause analysis with owner-gated closure |
+| learn | Evaluate session for long-term knowledge persistence |
+| session | Session lifecycle: new, save, load, switch, rename |
+| health | Memory system diagnostic: line counts, stale sessions, missing engrams |
+| review | Code review with holistic evaluation |
+| gap | Gap analysis before presenting code changes |
+
+### Always-On Rules (`.claude/rules/`)
+
+Load every session. Never trigger-based -- always active.
+Examples: trust zones, security guardrails, friction detection, verify-before-presenting, session-guardrail, autonomous-execution.
+
+### Cognition (`.claude/cognition/`)
+
+- `personas.md` -- specialist personas activated per-request
+- `anti-patterns.md` -- learned mistakes to avoid
+- `decisions/` -- decision frameworks (RCA, technology selection)
+
+### Bundles (`.claude/bundles/`)
+
+Domain knowledge loaded on demand via routing weights. Personal only in v0.4.5.
+Line limit: warn at 230, hard cap at 280.
+
+### Engrams (`.claude/engrams/`)
+
+Per-project deep context updated by `/learn` at sprint completion or on architecture changes.
+Line limit: warn at 230, hard cap at 280.
+
+## Key Principles
+
+- **DOE Framework:** Directive Orchestration Execution -- guardrails override goals
+- **Reliability-first, security-aware** engineering identity
+- **Fail fast over fail silently**
+- **Follow existing patterns before inventing new ones**
+- **Skills model:** composable, shareable, portable across Anthropic ecosystem
+- **Open-source:** use "Owner" in all published docs, never personal names
+
+## Conventions
+
+| Convention | Value |
+|---|---|
+| File versioning | Name-01.md, Name-02.md (CLAUDE.md exempt; Hub.md never versioned) |
+| Hub.md | Never versioned, never deleted, updated in place |
+| Output | ASCII only, no emojis, no special characters |
+| MEMORY.md line limit | 200 (hard, truncated by Claude Code) |
+| Bundle/Engram line limit | 280 (warn at 230) |
+| Session tag | `[session: <name> | DIV: <MODE>]` |
+| Domain guard | jitneuro.ai primary; NEVER jitai.com -- always jitai.co |
+
+## Integration Points
+
+- **Ghost CMS** -- blog publishing via API
+- **GitHub** -- gh CLI, fine-grained PAT auth (expires 2026-07-31)
+- **N8N** -- workflow automation (Python requests only -- curl 500s from shell escaping)
+- **jit-knowledge** -- canonical shared knowledge repo; this repo is subscribed via `notify-jit-knowledge.yml`
+
+## jit-knowledge Subscription
+
+This repo is subscribed to `dstolts/jit-knowledge`'s `refresh-index` workflow.
+Changes under `.jitneuro/{engrams,bundles,rules,cognition}/**` on `main` trigger
+`.github/workflows/notify-jit-knowledge.yml` -> `repository_dispatch` -> jit-knowledge regenerates `INDEX.md`.
+
+Token: `JITAI_OPENCLAW_PROD` secret (fine-grained PAT, Contents:write on `dstolts/jit-knowledge` only).
+
+## CoWork / Paperclip Agent Execution
+
+Paperclip agents run on `automate1` (192.168.1.155), Docker port 3100, UI: `digital.jitai.co`.
+
+- Repo mounted at `/repos/` inside container; agents run `claude --dangerously-skip-permissions`
+- Agent instructions from `CoWork/agents/<agent-name>/AGENTS.md` (canonical: `jit-knowledge/org/`)
+- Create GH issue + `paperclip-dispatch` label + `agent:<role>` -> GitHub Actions dispatch -> Paperclip
+- Direct API: `POST /api/companies/8167d96e-7a97-4c37-9882-bbf724ed136c/issues`
+- Blocked issues: set `status=blocked` via API with numbered Owner action steps
+
+### Agent roster
+
+| Agent | Scope |
+|-------|-------|
+| Repo agent | Code quality guardian for this repo |
+| sys-backend | API/server code changes |
+| sys-frontend | Client/UI changes |
+| sys-qa | Test suites |
+| sys-security | Security audit (advisory only) |
+| sys-devops | `.github/workflows/`, infra scripts |
+| sys-architect | Architecture decisions |
+
+## Not-this list
+
+- NOT a compiled application -- pure Markdown + shell scripts
+- NOT a SaaS product -- installs into user's Claude Code workspace
+- NOT owner-specific -- all templates use "Owner" / "user" / "project owner"; never personal names
+- NOT jitai.com -- always jitai.co for product domains


### PR DESCRIPTION
## Summary

- Migrates `C:/Users/dstolts/Code/.claude/engrams/jitneuro-context.md` into canonical in-repo location `.jitneuro/engrams/context.md` with YAML frontmatter, reshaped body (165 lines), and updated stale `D:/Code` paths.
- Installs `.github/workflows/notify-jit-knowledge.yml` (copied verbatim from template) so jit-knowledge regenerates its INDEX.md on every `.jitneuro/**` push to main.
- Uses already-provisioned `JITAI_OPENCLAW_PROD` secret.
- Step 4 item 5 of `dstolts/jit-knowledge` single-source-of-truth plan.

## Files changed

| File | Change |
|------|--------|
| `.jitneuro/engrams/context.md` | New -- canonical engram (migrated + reshaped) |
| `.github/workflows/notify-jit-knowledge.yml` | New -- jit-knowledge dispatch trigger |

## Engram details

- 12 domains: `jitneuro`, `jitneuro.ai`, `DOE`, `framework`, `JitNeuro`, `directive-orchestration-execution`, `templates`, `cognition`, `bundles-system`, `skills`, `hooks`, `slash-commands`, `open-source-framework`
- Body: 165 lines covering identity, architecture, key paths, skills table, principles, conventions, integration points, jit-knowledge subscription section, Paperclip agent roster, not-this list
- Stale path corrections: `D:/Code/jitneuro` -> `C:/Users/dstolts/Code/jitneuro` throughout

## Test plan

- [x] Files staged and committed (method: git status confirms 2 new files, 226 insertions)
- [x] Branch pushed, PR opened (method: gh pr create)
- [ ] Merge triggers notify-jit-knowledge.yml (method: GH Actions run log after merge to main)

## Follow-ups

- Source engram at `C:/Users/dstolts/Code/.claude/engrams/jitneuro-context.md` can be soft-deprecated after jit-knowledge INDEX.md picks up this canonical file
- `templates/.github/workflows/notify-jit-knowledge.yml` path in templates/ does not exist on disk (template was read from git history on step2 branch); create that file in a follow-up to complete the template set