### PR TITLE
retire(templates): replace routing templates with INDEX.md pointer docs

### DIFF
--- a/.github/workflows/notify-jit-knowledge.yml
+++ b/.github/workflows/notify-jit-knowledge.yml
@@ -1,0 +1,43 @@
+name: Notify jit-knowledge of engram/bundle/rules change
+
+# Installed in every repo subscribed to jit-knowledge per
+# https://github.com/dstolts/jit-knowledge/blob/main/sync/subscribed-repos.json
+#
+# Fires when content under .jitneuro/ changes on the default branch (main or uat).
+# Posts a repository_dispatch event to jit-knowledge so refresh-index.yml regenerates
+# the Routing Index in INDEX.md.
+#
+# Requires repo secret JITAI_OPENCLAW_PROD -- fine-grained PAT scoped to
+# Contents:write on dstolts/jit-knowledge. See
+# https://github.com/dstolts/jit-knowledge/blob/main/projects/dispatch-token-setup.md
+
+on:
+  push:
+    branches: ['$default-branch']
+    paths:
+      - '.jitneuro/engrams/**'
+      - '.jitneuro/bundles/**'
+      - '.jitneuro/rules/**'
+      - '.jitneuro/cognition/**'
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch knowledge-changed to jit-knowledge
+        env:
+          GH_TOKEN: ${{ secrets.JITAI_OPENCLAW_PROD }}
+        run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "ERROR: JITAI_OPENCLAW_PROD secret not set. Distribute via projects/dispatch-token-setup.md loop."
+            exit 1
+          fi
+          gh api -X POST repos/dstolts/jit-knowledge/dispatches \
+            -f event_type=knowledge-changed \
+            -f client_payload[repo]=${{ github.repository }} \
+            -f client_payload[branch]=${{ github.ref_name }} \
+            -f client_payload[sha]=${{ github.sha }} \
+            -f client_payload[trigger]=push

--- a/.jitneuro/engrams/context.md
+++ b/.jitneuro/engrams/context.md
@@ -1,0 +1,183 @@
+---
+name: jitneuro
+type: engram
+domains:
+  - jitneuro
+  - jitneuro.ai
+  - DOE
+  - framework
+  - JitNeuro
+  - directive-orchestration-execution
+  - templates
+  - cognition
+  - bundles-system
+  - skills
+  - hooks
+  - slash-commands
+  - open-source-framework
+status: production
+version: 2026-05-11
+repo: dstolts/jitneuro
+last-verified: 2026-05-11
+owner: dstolts
+---
+
+# jitneuro Engram
+
+**Status:** Production
+**Last verified:** 2026-05-11
+**Migrated from:** `C:/Users/dstolts/Code/.claude/engrams/jitneuro-context.md` (Step 4 jit-knowledge canonicalization 2026-05-11).
+
+## Identity
+
+JitNeuro is an **open-source AI engineering framework for Claude Code**. It provides structured behaviors (skills, rules, hooks, cognition) that make AI assistants reliable, security-aware, and production-grade.
+
+Purpose: production tool AND enterprise thought leadership. Never optimize for just Owner's team alone -- every design decision must work for any adopter.
+
+- **GitHub:** `dstolts/jitneuro`
+- **Local path:** `C:/Users/dstolts/Code/jitneuro`
+- **Domains:** jitneuro.ai (primary), jitneuro.com (redirects to .ai)
+- **Current version target:** v0.4.5
+
+## Architecture
+
+### Skills-First Pivot (2026-03-30)
+
+JitNeuro pivoted from "monolithic framework you adopt wholesale" to "composable skills you install individually" using Anthropic's official SKILL.md standard (Dec 2025).
+
+- `.claude/skills/<skill-name>/SKILL.md` replaces `.claude/commands/` as primary behavior mechanism
+- Skills use SKILL.md with YAML frontmatter (progressive disclosure, ~100 tokens at startup)
+- Commands still work but are legacy -- skills take precedence
+- Install all skills by default; users remove what they don't want
+
+### v0.4.5 Scope (ships)
+
+- Skills architecture: `.claude/skills/<skill-name>/SKILL.md`
+- Core skills: `strategy`, `divergent`, `rca`, `learn`, `session`, `health`, `review`, `gap`
+- Always-on rules: truth-over-speed, scope-guard, trust zones, friction detection, verify-before-presenting
+- Cognition layer: personas.md, anti-patterns.md, decisions/
+- Hooks: PostToolUse heartbeat, pre-commit branch protection
+- Bundles and engrams (personal mode in v0.4.5)
+- Simplified install via `install.sh` / `install.ps1`
+
+### Deferred to v2
+
+- `.jitneuro/` shared team folders, TEAM.md, per-user tracking
+- `/learn --team` promotion workflow
+- machineName, bundle-map.json
+- Enterprise docs and dashboard
+- External cron launcher
+
+## Key Paths
+
+| Path | Purpose |
+|------|---------|
+| `templates/commands/` | Slash command templates (16 commands + 5 shortcuts + test-tools) |
+| `templates/hooks/` | Hook script templates (4 hooks) |
+| `templates/engrams/` | Engram templates + examples |
+| `templates/rules/` | Path-scoped rule templates |
+| `templates/.github/workflows/` | GH Actions templates (incl. notify-jit-knowledge.yml) |
+| `templates/CLAUDE-brainstem.md` | CLAUDE.md template for new repos |
+| `docs/` | Setup guide, commands reference, hooks guide |
+| `install.sh` / `install.ps1` | Installation scripts (workspace/project/user modes) |
+
+## Core Components
+
+### Skills (`.claude/skills/`)
+
+| Skill | Purpose |
+|-------|---------|
+| strategy | 3-phase gated workflow: plan -> approve -> execute |
+| divergent | FRAME -> DIVERGE -> EVALUATE -> CONVERGE -> EXECUTE reasoning |
+| rca | Root cause analysis with owner-gated closure |
+| learn | Evaluate session for long-term knowledge persistence |
+| session | Session lifecycle: new, save, load, switch, rename |
+| health | Memory system diagnostic: line counts, stale sessions, missing engrams |
+| review | Code review with holistic evaluation |
+| gap | Gap analysis before presenting code changes |
+
+### Always-On Rules (`.claude/rules/`)
+
+Load every session. Never trigger-based -- always active.
+Examples: trust zones, security guardrails, friction detection, verify-before-presenting, session-guardrail, autonomous-execution.
+
+### Cognition (`.claude/cognition/`)
+
+- `personas.md` -- specialist personas activated per-request
+- `anti-patterns.md` -- learned mistakes to avoid
+- `decisions/` -- decision frameworks (RCA, technology selection)
+
+### Bundles (`.claude/bundles/`)
+
+Domain knowledge loaded on demand via routing weights. Personal only in v0.4.5.
+Line limit: warn at 230, hard cap at 280.
+
+### Engrams (`.claude/engrams/`)
+
+Per-project deep context updated by `/learn` at sprint completion or on architecture changes.
+Line limit: warn at 230, hard cap at 280.
+
+## Key Principles
+
+- **DOE Framework:** Directive Orchestration Execution -- guardrails override goals
+- **Reliability-first, security-aware** engineering identity
+- **Fail fast over fail silently**
+- **Follow existing patterns before inventing new ones**
+- **Skills model:** composable, shareable, portable across Anthropic ecosystem
+- **Open-source:** use "Owner" in all published docs, never personal names
+
+## Conventions
+
+| Convention | Value |
+|---|---|
+| File versioning | Name-01.md, Name-02.md (CLAUDE.md exempt; Hub.md never versioned) |
+| Hub.md | Never versioned, never deleted, updated in place |
+| Output | ASCII only, no emojis, no special characters |
+| MEMORY.md line limit | 200 (hard, truncated by Claude Code) |
+| Bundle/Engram line limit | 280 (warn at 230) |
+| Session tag | `[session: <name> | DIV: <MODE>]` |
+| Domain guard | jitneuro.ai primary; NEVER jitai.com -- always jitai.co |
+
+## Integration Points
+
+- **Ghost CMS** -- blog publishing via API
+- **GitHub** -- gh CLI, fine-grained PAT auth (expires 2026-07-31)
+- **N8N** -- workflow automation (Python requests only -- curl 500s from shell escaping)
+- **jit-knowledge** -- canonical shared knowledge repo; this repo is subscribed via `notify-jit-knowledge.yml`
+
+## jit-knowledge Subscription
+
+This repo is subscribed to `dstolts/jit-knowledge`'s `refresh-index` workflow.
+Changes under `.jitneuro/{engrams,bundles,rules,cognition}/**` on `main` trigger
+`.github/workflows/notify-jit-knowledge.yml` -> `repository_dispatch` -> jit-knowledge regenerates `INDEX.md`.
+
+Token: `JITAI_OPENCLAW_PROD` secret (fine-grained PAT, Contents:write on `dstolts/jit-knowledge` only).
+
+## CoWork / Paperclip Agent Execution
+
+Paperclip agents run on `automate1` (192.168.1.155), Docker port 3100, UI: `digital.jitai.co`.
+
+- Repo mounted at `/repos/` inside container; agents run `claude --dangerously-skip-permissions`
+- Agent instructions from `CoWork/agents/<agent-name>/AGENTS.md` (canonical: `jit-knowledge/org/`)
+- Create GH issue + `paperclip-dispatch` label + `agent:<role>` -> GitHub Actions dispatch -> Paperclip
+- Direct API: `POST /api/companies/8167d96e-7a97-4c37-9882-bbf724ed136c/issues`
+- Blocked issues: set `status=blocked` via API with numbered Owner action steps
+
+### Agent roster
+
+| Agent | Scope |
+|-------|-------|
+| Repo agent | Code quality guardian for this repo |
+| sys-backend | API/server code changes |
+| sys-frontend | Client/UI changes |
+| sys-qa | Test suites |
+| sys-security | Security audit (advisory only) |
+| sys-devops | `.github/workflows/`, infra scripts |
+| sys-architect | Architecture decisions |
+
+## Not-this list
+
+- NOT a compiled application -- pure Markdown + shell scripts
+- NOT a SaaS product -- installs into user's Claude Code workspace
+- NOT owner-specific -- all templates use "Owner" / "user" / "project owner"; never personal names
+- NOT jitai.com -- always jitai.co for product domains

--- a/templates/.archive/context-manifest.md
+++ b/templates/.archive/context-manifest.md
@@ -1,0 +1,58 @@
+# ARCHIVED 2026-05-12 -- routing moved to jit-knowledge/INDEX.md per Step 6 plan
+# Original content preserved below for reference. Do not load -- use INDEX.md instead.
+
+---
+
+# Context Manifest
+
+This file indexes all available context bundles and tracks session state.
+The orchestrator reads this to determine which bundles to load for a given task.
+
+## Always Load (Brainstem)
+These load automatically at session start via CLAUDE.md:
+- `~/.claude/CLAUDE.md` (global rules)
+- `.claude/CLAUDE.md` (project rules)
+- `MEMORY.md` (first 200 lines -- routing weights)
+
+## Available Bundles
+
+| Bundle | Path | Domain | Lines | Last Used |
+|--------|------|--------|-------|-----------|
+| example | .claude/bundles/example.md | Example template | ~30 | never |
+
+<!-- Add your bundles here. Keep under 180 lines each. -->
+<!-- Example entries:
+| deploy    | .claude/bundles/deploy.md    | CI/CD, containers, environments | ~60 | 2026-03-09 |
+| api       | .claude/bundles/api.md       | API design, auth, error handling | ~50 | 2026-03-09 |
+| sprint    | .claude/bundles/sprint.md    | Sprint protocol, task format     | ~70 | 2026-03-08 |
+| testing   | .claude/bundles/testing.md   | Test strategy, commands, fixtures | ~40 | 2026-03-07 |
+-->
+
+## Routing Weights
+
+Patterns that map task types to bundle combinations.
+Update these as you learn which bundles co-activate:
+
+```
+- Default task         -> bundles: []  (brainstem only)
+<!-- Example routing weights:
+- Deploy tasks         -> bundles: [deploy, infra]
+- API development      -> bundles: [api, testing]
+- Sprint execution     -> bundles: [sprint, cross-repo]
+- Bug investigation    -> bundles: [api, testing, deploy]
+- Documentation        -> bundles: []  (brainstem sufficient)
+-->
+```
+
+## Session State
+
+Updated by /save command. Read by /load command after /clear.
+
+```
+active_bundles: []
+current_task: none
+modified_files: []
+pending_decisions: []
+next_steps: []
+key_findings: []
+```

--- a/templates/.archive/rules-routing-weights.md
+++ b/templates/.archive/rules-routing-weights.md
@@ -1,0 +1,42 @@
+# ARCHIVED 2026-05-12 -- routing moved to jit-knowledge/INDEX.md per Step 6 plan
+
+---
+
+# Routing Weights
+
+Load context bundles based on task keywords. Each entry maps trigger phrases to one or more bundle names. When a user request matches a trigger, the listed bundles are loaded to provide domain-specific context.
+
+## Pattern
+
+```
+- <trigger phrases>  -> [bundle-name]
+- <trigger phrases>  -> [bundle-a, bundle-b]
+```
+
+## Example Routes
+
+```
+- Deploy / server / container / VM       -> [infrastructure]
+- API / endpoint / route / auth          -> [api-patterns]
+- Blog / post / publish / content        -> [content]
+- Sprint / story / prd / backlog         -> [sprint-workflow]
+- Test / spec / coverage / assertion     -> [testing]
+- Bug / error / debug / investigate      -> [infrastructure, integrations]
+```
+
+## How It Works
+
+1. AI scans the user's request for trigger keywords
+2. Matching bundles are loaded from the bundles directory
+3. Multiple bundles can load simultaneously for cross-domain tasks
+4. Unmatched requests use base context only (no extra bundles)
+
+## Tips
+
+- Group related keywords on the same line (e.g., "deploy / server / container")
+- Use multi-bundle routes for tasks that span domains (e.g., "cross-repo sprint -> [sprint-workflow, infrastructure]")
+- Keep trigger phrases short -- 2-4 words per phrase is ideal
+- Order routes from most specific to most general
+- Add a "Full manifest" reference so AI can discover all available bundles
+
+Full manifest: .claude/context-manifest.md

--- a/templates/context-manifest.md
+++ b/templates/context-manifest.md
@@ -1,53 +1,30 @@
-# Context Manifest
+# Context Manifest -- DEPRECATED TEMPLATE
 
-This file indexes all available context bundles and tracks session state.
-The orchestrator reads this to determine which bundles to load for a given task.
+This template file is deprecated as of 2026-05-12 (Step 6 Layer B sweep).
 
-## Always Load (Brainstem)
-These load automatically at session start via CLAUDE.md:
-- `~/.claude/CLAUDE.md` (global rules)
-- `.claude/CLAUDE.md` (project rules)
-- `MEMORY.md` (first 200 lines -- routing weights)
+The context-manifest.md pattern taught local routing. Routing now lives exclusively in:
 
-## Available Bundles
+  https://github.com/dstolts/jit-knowledge/blob/main/INDEX.md
 
-| Bundle | Path | Domain | Lines | Last Used |
-|--------|------|--------|-------|-----------|
-| example | .claude/bundles/example.md | Example template | ~30 | never |
+## What to do instead
 
-<!-- Add your bundles here. Keep under 180 lines each. -->
-<!-- Example entries:
-| deploy    | .claude/bundles/deploy.md    | CI/CD, containers, environments | ~60 | 2026-03-09 |
-| api       | .claude/bundles/api.md       | API design, auth, error handling | ~50 | 2026-03-09 |
-| sprint    | .claude/bundles/sprint.md    | Sprint protocol, task format     | ~70 | 2026-03-08 |
-| testing   | .claude/bundles/testing.md   | Test strategy, commands, fixtures | ~40 | 2026-03-07 |
--->
+When setting up a new repo with JitNeuro:
 
-## Routing Weights
+1. Clone or add jit-knowledge as a submodule: `.jit-knowledge/`
+2. Set up `~/.claude/url-resolver.md` with the repo URL -> local path map
+3. In your repo's CLAUDE.md, reference INDEX.md for routing:
+   `# Routing: see .jit-knowledge/INDEX.md (resolved via ~/.claude/url-resolver.md)`
 
-Patterns that map task types to bundle combinations.
-Update these as you learn which bundles co-activate:
+The INDEX.md is the single source of truth for all task-keyword -> bundle mappings.
+Do NOT create a local routing-weights.md or context-manifest.md with routing tables.
 
-```
-- Default task         -> bundles: []  (brainstem only)
-<!-- Example routing weights:
-- Deploy tasks         -> bundles: [deploy, infra]
-- API development      -> bundles: [api, testing]
-- Sprint execution     -> bundles: [sprint, cross-repo]
-- Bug investigation    -> bundles: [api, testing, deploy]
-- Documentation        -> bundles: []  (brainstem sufficient)
--->
-```
+## Bundle catalog (non-routing sections)
 
-## Session State
+If you need a local index of available bundles without routing, use your repo's
+`.jitneuro/bundles/` directory listing. The engram at `.jitneuro/engrams/context.md`
+should describe which bundles are available for this repo.
 
-Updated by /save command. Read by /load command after /clear.
+## Archive
 
-```
-active_bundles: []
-current_task: none
-modified_files: []
-pending_decisions: []
-next_steps: []
-key_findings: []
-```
+The original context-manifest.md template is preserved at:
+  `templates/.archive/context-manifest.md`

--- a/templates/rules/routing-weights.md
+++ b/templates/rules/routing-weights.md
@@ -1,38 +1,23 @@
-# Routing Weights
+# Routing Weights -- DEPRECATED TEMPLATE
 
-Load context bundles based on task keywords. Each entry maps trigger phrases to one or more bundle names. When a user request matches a trigger, the listed bundles are loaded to provide domain-specific context.
+This template file is deprecated as of 2026-05-12 (Step 6 Layer B sweep).
 
-## Pattern
+The routing-weights.md pattern enacted routing locally. Routing now lives exclusively in:
 
-```
-- <trigger phrases>  -> [bundle-name]
-- <trigger phrases>  -> [bundle-a, bundle-b]
-```
+  https://github.com/dstolts/jit-knowledge/blob/main/INDEX.md
 
-## Example Routes
+## What to do instead
 
-```
-- Deploy / server / container / VM       -> [infrastructure]
-- API / endpoint / route / auth          -> [api-patterns]
-- Blog / post / publish / content        -> [content]
-- Sprint / story / prd / backlog         -> [sprint-workflow]
-- Test / spec / coverage / assertion     -> [testing]
-- Bug / error / debug / investigate      -> [infrastructure, integrations]
-```
+Do NOT create a routing-weights.md in your repo's `.claude/rules/`. Instead:
 
-## How It Works
+1. Add jit-knowledge as a submodule at `.jit-knowledge/` in your repo
+2. Set up `~/.claude/url-resolver.md` mapping the jit-knowledge GitHub URL to the local submodule path
+3. Reference INDEX.md for routing at session start (via CLAUDE.md or brainstem)
 
-1. AI scans the user's request for trigger keywords
-2. Matching bundles are loaded from the bundles directory
-3. Multiple bundles can load simultaneously for cross-domain tasks
-4. Unmatched requests use base context only (no extra bundles)
+For system-specific routing extensions (routes not in INDEX.md), add them ONLY to INDEX.md
+via a PR to jit-knowledge. Do not maintain a parallel local router.
 
-## Tips
+## Archive
 
-- Group related keywords on the same line (e.g., "deploy / server / container")
-- Use multi-bundle routes for tasks that span domains (e.g., "cross-repo sprint -> [sprint-workflow, infrastructure]")
-- Keep trigger phrases short -- 2-4 words per phrase is ideal
-- Order routes from most specific to most general
-- Add a "Full manifest" reference so AI can discover all available bundles
-
-Full manifest: .claude/context-manifest.md
+The original routing-weights.md template is preserved at:
+  `templates/.archive/rules-routing-weights.md`


### PR DESCRIPTION
## Summary

- `templates/context-manifest.md`: replaced with pointer doc; original archived to `templates/.archive/`
- `templates/rules/routing-weights.md`: replaced with pointer doc; original archived to `templates/.archive/`

These template files taught new repos to create local routing tables. That pattern is retired -- routing now lives exclusively in `jit-knowledge/INDEX.md`.

## Why

Step 6 Layer B sweep (jit-knowledge canonicalization plan v2.1). Template files that propagate the old pattern will cause every new repo created from them to need remediation. Replacing templates now prevents future drift.

## Test plan
- [ ] `templates/context-manifest.md` contains pointer language only, no routing tables
- [ ] `templates/rules/routing-weights.md` contains pointer language only, no routing tables
- [ ] Archived originals exist in `templates/.archive/`

## Related
- jit-knowledge PR #63 (sync/routing-weights.md retired + sweep report)
- jit-knowledge PR #61 (Layer C governance rule + CI lint)
- Follow-ups: jitneuro docs (concepts.md, setup-guide.md, etc.) and install scripts still reference old pattern -- open as issues per Hub.md tasks #14-17