### PR TITLE
docs(step6): teach INDEX.md single-source routing in jitneuro docs and install scripts

### DIFF
--- a/.github/workflows/notify-jit-knowledge.yml
+++ b/.github/workflows/notify-jit-knowledge.yml
@@ -1,0 +1,43 @@
+name: Notify jit-knowledge of engram/bundle/rules change
+
+# Installed in every repo subscribed to jit-knowledge per
+# https://github.com/dstolts/jit-knowledge/blob/main/sync/subscribed-repos.json
+#
+# Fires when content under .jitneuro/ changes on the default branch (main or uat).
+# Posts a repository_dispatch event to jit-knowledge so refresh-index.yml regenerates
+# the Routing Index in INDEX.md.
+#
+# Requires repo secret JITAI_OPENCLAW_PROD -- fine-grained PAT scoped to
+# Contents:write on dstolts/jit-knowledge. See
+# https://github.com/dstolts/jit-knowledge/blob/main/projects/dispatch-token-setup.md
+
+on:
+  push:
+    branches: ['$default-branch']
+    paths:
+      - '.jitneuro/engrams/**'
+      - '.jitneuro/bundles/**'
+      - '.jitneuro/rules/**'
+      - '.jitneuro/cognition/**'
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch knowledge-changed to jit-knowledge
+        env:
+          GH_TOKEN: ${{ secrets.JITAI_OPENCLAW_PROD }}
+        run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "ERROR: JITAI_OPENCLAW_PROD secret not set. Distribute via projects/dispatch-token-setup.md loop."
+            exit 1
+          fi
+          gh api -X POST repos/dstolts/jit-knowledge/dispatches \
+            -f event_type=knowledge-changed \
+            -f client_payload[repo]=${{ github.repository }} \
+            -f client_payload[branch]=${{ github.ref_name }} \
+            -f client_payload[sha]=${{ github.sha }} \
+            -f client_payload[trigger]=push

--- a/.jitneuro/engrams/context.md
+++ b/.jitneuro/engrams/context.md
@@ -1,0 +1,183 @@
+---
+name: jitneuro
+type: engram
+domains:
+  - jitneuro
+  - jitneuro.ai
+  - DOE
+  - framework
+  - JitNeuro
+  - directive-orchestration-execution
+  - templates
+  - cognition
+  - bundles-system
+  - skills
+  - hooks
+  - slash-commands
+  - open-source-framework
+status: production
+version: 2026-05-11
+repo: dstolts/jitneuro
+last-verified: 2026-05-11
+owner: dstolts
+---
+
+# jitneuro Engram
+
+**Status:** Production
+**Last verified:** 2026-05-11
+**Migrated from:** `C:/Users/dstolts/Code/.claude/engrams/jitneuro-context.md` (Step 4 jit-knowledge canonicalization 2026-05-11).
+
+## Identity
+
+JitNeuro is an **open-source AI engineering framework for Claude Code**. It provides structured behaviors (skills, rules, hooks, cognition) that make AI assistants reliable, security-aware, and production-grade.
+
+Purpose: production tool AND enterprise thought leadership. Never optimize for just Owner's team alone -- every design decision must work for any adopter.
+
+- **GitHub:** `dstolts/jitneuro`
+- **Local path:** `C:/Users/dstolts/Code/jitneuro`
+- **Domains:** jitneuro.ai (primary), jitneuro.com (redirects to .ai)
+- **Current version target:** v0.4.5
+
+## Architecture
+
+### Skills-First Pivot (2026-03-30)
+
+JitNeuro pivoted from "monolithic framework you adopt wholesale" to "composable skills you install individually" using Anthropic's official SKILL.md standard (Dec 2025).
+
+- `.claude/skills/<skill-name>/SKILL.md` replaces `.claude/commands/` as primary behavior mechanism
+- Skills use SKILL.md with YAML frontmatter (progressive disclosure, ~100 tokens at startup)
+- Commands still work but are legacy -- skills take precedence
+- Install all skills by default; users remove what they don't want
+
+### v0.4.5 Scope (ships)
+
+- Skills architecture: `.claude/skills/<skill-name>/SKILL.md`
+- Core skills: `strategy`, `divergent`, `rca`, `learn`, `session`, `health`, `review`, `gap`
+- Always-on rules: truth-over-speed, scope-guard, trust zones, friction detection, verify-before-presenting
+- Cognition layer: personas.md, anti-patterns.md, decisions/
+- Hooks: PostToolUse heartbeat, pre-commit branch protection
+- Bundles and engrams (personal mode in v0.4.5)
+- Simplified install via `install.sh` / `install.ps1`
+
+### Deferred to v2
+
+- `.jitneuro/` shared team folders, TEAM.md, per-user tracking
+- `/learn --team` promotion workflow
+- machineName, bundle-map.json
+- Enterprise docs and dashboard
+- External cron launcher
+
+## Key Paths
+
+| Path | Purpose |
+|------|---------|
+| `templates/commands/` | Slash command templates (16 commands + 5 shortcuts + test-tools) |
+| `templates/hooks/` | Hook script templates (4 hooks) |
+| `templates/engrams/` | Engram templates + examples |
+| `templates/rules/` | Path-scoped rule templates |
+| `templates/.github/workflows/` | GH Actions templates (incl. notify-jit-knowledge.yml) |
+| `templates/CLAUDE-brainstem.md` | CLAUDE.md template for new repos |
+| `docs/` | Setup guide, commands reference, hooks guide |
+| `install.sh` / `install.ps1` | Installation scripts (workspace/project/user modes) |
+
+## Core Components
+
+### Skills (`.claude/skills/`)
+
+| Skill | Purpose |
+|-------|---------|
+| strategy | 3-phase gated workflow: plan -> approve -> execute |
+| divergent | FRAME -> DIVERGE -> EVALUATE -> CONVERGE -> EXECUTE reasoning |
+| rca | Root cause analysis with owner-gated closure |
+| learn | Evaluate session for long-term knowledge persistence |
+| session | Session lifecycle: new, save, load, switch, rename |
+| health | Memory system diagnostic: line counts, stale sessions, missing engrams |
+| review | Code review with holistic evaluation |
+| gap | Gap analysis before presenting code changes |
+
+### Always-On Rules (`.claude/rules/`)
+
+Load every session. Never trigger-based -- always active.
+Examples: trust zones, security guardrails, friction detection, verify-before-presenting, session-guardrail, autonomous-execution.
+
+### Cognition (`.claude/cognition/`)
+
+- `personas.md` -- specialist personas activated per-request
+- `anti-patterns.md` -- learned mistakes to avoid
+- `decisions/` -- decision frameworks (RCA, technology selection)
+
+### Bundles (`.claude/bundles/`)
+
+Domain knowledge loaded on demand via routing weights. Personal only in v0.4.5.
+Line limit: warn at 230, hard cap at 280.
+
+### Engrams (`.claude/engrams/`)
+
+Per-project deep context updated by `/learn` at sprint completion or on architecture changes.
+Line limit: warn at 230, hard cap at 280.
+
+## Key Principles
+
+- **DOE Framework:** Directive Orchestration Execution -- guardrails override goals
+- **Reliability-first, security-aware** engineering identity
+- **Fail fast over fail silently**
+- **Follow existing patterns before inventing new ones**
+- **Skills model:** composable, shareable, portable across Anthropic ecosystem
+- **Open-source:** use "Owner" in all published docs, never personal names
+
+## Conventions
+
+| Convention | Value |
+|---|---|
+| File versioning | Name-01.md, Name-02.md (CLAUDE.md exempt; Hub.md never versioned) |
+| Hub.md | Never versioned, never deleted, updated in place |
+| Output | ASCII only, no emojis, no special characters |
+| MEMORY.md line limit | 200 (hard, truncated by Claude Code) |
+| Bundle/Engram line limit | 280 (warn at 230) |
+| Session tag | `[session: <name> | DIV: <MODE>]` |
+| Domain guard | jitneuro.ai primary; NEVER jitai.com -- always jitai.co |
+
+## Integration Points
+
+- **Ghost CMS** -- blog publishing via API
+- **GitHub** -- gh CLI, fine-grained PAT auth (expires 2026-07-31)
+- **N8N** -- workflow automation (Python requests only -- curl 500s from shell escaping)
+- **jit-knowledge** -- canonical shared knowledge repo; this repo is subscribed via `notify-jit-knowledge.yml`
+
+## jit-knowledge Subscription
+
+This repo is subscribed to `dstolts/jit-knowledge`'s `refresh-index` workflow.
+Changes under `.jitneuro/{engrams,bundles,rules,cognition}/**` on `main` trigger
+`.github/workflows/notify-jit-knowledge.yml` -> `repository_dispatch` -> jit-knowledge regenerates `INDEX.md`.
+
+Token: `JITAI_OPENCLAW_PROD` secret (fine-grained PAT, Contents:write on `dstolts/jit-knowledge` only).
+
+## CoWork / Paperclip Agent Execution
+
+Paperclip agents run on `automate1` (192.168.1.155), Docker port 3100, UI: `digital.jitai.co`.
+
+- Repo mounted at `/repos/` inside container; agents run `claude --dangerously-skip-permissions`
+- Agent instructions from `CoWork/agents/<agent-name>/AGENTS.md` (canonical: `jit-knowledge/org/`)
+- Create GH issue + `paperclip-dispatch` label + `agent:<role>` -> GitHub Actions dispatch -> Paperclip
+- Direct API: `POST /api/companies/8167d96e-7a97-4c37-9882-bbf724ed136c/issues`
+- Blocked issues: set `status=blocked` via API with numbered Owner action steps
+
+### Agent roster
+
+| Agent | Scope |
+|-------|-------|
+| Repo agent | Code quality guardian for this repo |
+| sys-backend | API/server code changes |
+| sys-frontend | Client/UI changes |
+| sys-qa | Test suites |
+| sys-security | Security audit (advisory only) |
+| sys-devops | `.github/workflows/`, infra scripts |
+| sys-architect | Architecture decisions |
+
+## Not-this list
+
+- NOT a compiled application -- pure Markdown + shell scripts
+- NOT a SaaS product -- installs into user's Claude Code workspace
+- NOT owner-specific -- all templates use "Owner" / "user" / "project owner"; never personal names
+- NOT jitai.com -- always jitai.co for product domains

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@
 
 ```
 LONG-TERM MEMORY (disk -- survives all sessions)
-  |-- MEMORY.md            learned patterns + routing weights
+  |-- MEMORY.md            project index + business facts
   |-- bundles/             domain knowledge, loaded on-demand
   |-- engrams/             per-project deep context (updated by /learn)
   |-- specs + decisions    procedural + episodic memory
@@ -41,11 +41,11 @@ SHORT-TERM MEMORY (checkpoint files -- survives /clear)
 ```
 SESSION START
   |-- CLAUDE.md loads (brainstem -- always, kept minimal)
-  |-- MEMORY.md loads (routing weights -- first 200 lines)
+  |-- MEMORY.md loads (project index -- first 200 lines)
   |-- Check session-state.md (any prior state to resume?)
   |
   |-- User gives a task
-  |-- Orchestrator reads manifest, picks bundles
+  |-- Orchestrator reads jit-knowledge/INDEX.md (routing), picks bundles
   |-- Launches agent with ONLY those bundles
   |-- Agent works in isolated context, returns summary
   |-- Main context stays thin

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -26,15 +26,24 @@ Bundles and engrams are orthogonal:
 - **Bundles** cut across projects by domain ("how to deploy")
 - **Engrams** cut across domains by project ("everything about this repo")
 
-## Routing Weights
+## Routing
 
-Patterns in MEMORY.md that map task types to bundle combinations:
+Routing maps task keywords to bundle combinations so the right domain knowledge loads automatically.
+
+Routing has a single source of truth: `jit-knowledge/INDEX.md`. All task-keyword to bundle mappings live there. Consuming systems (per-repo installs, Cursor, future agents) reference INDEX.md rather than maintaining their own routing tables.
+
 ```
-- Deploy tasks -> bundles: [deploy, infra]
-- API work -> bundles: [api-design, testing]
-- Sprint execution -> bundles: [sprint, cross-repo]
+# jit-knowledge/INDEX.md (single source -- do not duplicate locally)
+- Deploy / server / container / VM  -> [infrastructure]
+- API / endpoint / route / auth     -> [api-patterns]
+- Sprint / story / prd / backlog    -> [sprint-workflow]
 ```
-These improve over time as the system learns which bundles co-activate.
+
+The URL-resolver (`~/.claude/url-resolver.md`) maps the canonical GitHub URL to the local clone path so each machine reads the file locally at session speed.
+
+For the governance rule, see `jit-knowledge/rules/routing-single-source.md`. To retire legacy routing files on an existing install, run `jit-knowledge/scripts/cleanup-old-routing.ps1` (Windows) or `cleanup-old-routing.sh` (Linux/Mac).
+
+Do NOT create a `routing-weights.md` or populate `context-manifest.md` with routing tables. Those are retired surfaces.
 
 ## Conversation Logging
 
@@ -81,12 +90,12 @@ CLAUDE.md (brainstem, 30-40 lines)    -- universal rules only
   .claude/rules/deployment.md          -- loads only for deploy/**, Dockerfile, .github/workflows/**
   .claude/bundles/deploy.md            -- loads on demand by orchestrator
   .claude/engrams/repo.md              -- loads on demand per project
-  MEMORY.md                            -- routing weights (first 200 lines)
+  MEMORY.md                            -- project index + business facts (routing is in jit-knowledge/INDEX.md)
 ```
 
 Each level only loads when relevant:
 - **Rules** load automatically when Claude touches matching file paths (zero cost when not needed)
-- **Bundles** load on demand when routing weights match the task
+- **Bundles** load on demand when INDEX.md routing matches the task
 - **Engrams** load on demand when working on a specific project
 - **CLAUDE.md** loads every session (keep it minimal)
 
@@ -115,7 +124,7 @@ JitNeuro is designed to be lightweight. Here's what it actually costs:
 |------|-------|-------------|---------|
 | CLAUDE.md (global) | ~50-140 | ~400-1,100 | Core rules, trust zones |
 | CLAUDE.md (project) | ~30-50 | ~250-400 | Project identity, key paths |
-| MEMORY.md | ~90-200 | ~700-1,600 | Routing weights, project index |
+| MEMORY.md | ~90-200 | ~700-1,600 | Project index, business facts (routing is in jit-knowledge/INDEX.md) |
 | **Total brainstem** | **~170-390** | **~1,350-3,100** | |
 
 That's roughly **1-2% of a 200K context window**. The rest is your conversation and code.

--- a/docs/cursor-and-cross-vendor.md
+++ b/docs/cursor-and-cross-vendor.md
@@ -8,7 +8,7 @@ This doc answers: (1) Can Cursor leverage JitNeuro without change? (2) What chan
 
 | Layer | Cursor as-is? | Cross-vendor approach |
 |-------|----------------|------------------------|
-| **Bundles, engrams, session-state, manifest** | ✅ Yes (read/write same paths) | Use vendor-neutral dir (e.g. `.ai/`) so both read same files |
+| **Bundles, engrams, session-state** | ✅ Yes (read/write same paths) | Use vendor-neutral dir (e.g. `.ai/`) so both read same files |
 | **Brainstem / core rules** | ⚠️ Adapt | Map CLAUDE.md → Cursor rules or AGENTS.md |
 | **Slash commands** | ❌ No | Commands become “intent docs” + one Cursor rule that routes to them |
 | **Hooks** | ❌ No | Claude-only; Cursor gets best-effort or no hooks |
@@ -20,13 +20,14 @@ This doc answers: (1) Can Cursor leverage JitNeuro without change? (2) What chan
 
 - **Content under `.claude/`**  
   Cursor can read and write the same files Claude Code uses:
-  - `context-manifest.md` (bundle index, routing)
   - `bundles/*.md`
   - `engrams/*.md`
   - `session-state/*.md`
   - `jitneuro.json`
+  - `.jit-knowledge/INDEX.md` (routing -- the single source via submodule)
+  - `~/.claude/url-resolver.md` (GitHub URL -> local clone map)
 
-  So the *concepts* (bundles, engrams, session state, routing) work in Cursor; the agent just needs to be told where they live and when to use them.
+  So the *concepts* (bundles, engrams, session state, routing) work in Cursor; the agent just needs to be told where they live and when to use them. Routing comes from INDEX.md, not from a per-repo `context-manifest.md`.
 
 - **Workflows**  
   “Load bundle X for this task”, “save session state”, “read manifest for routing” are all file I/O. Cursor can do that from prompts or rules; no Claude-specific API is required.
@@ -86,9 +87,10 @@ So: **no code change to JitNeuro**; only documentation and, optionally, a separa
   - Or put it in AGENTS.md and point Cursor at that file.  
   No need to change the *content* of the brainstem; only the *injection mechanism* (Claude = CLAUDE.md, Cursor = rule or AGENTS.md).
 
-- **MEMORY.md / routing:**  
-  Treat as a referenced doc: “When deciding which bundles to load, read MEMORY.md (and context-manifest) and use the routing weights.”  
-  Add that to the same Cursor rule or to the “command router” rule so the agent always has the instruction to consult MEMORY + manifest.
+- **MEMORY.md / routing:**
+  Routing is no longer in MEMORY.md or context-manifest.md. It lives exclusively in `jit-knowledge/INDEX.md`.
+  Add one Cursor rule or AGENTS.md block: “When deciding which bundles to load, read `.jit-knowledge/INDEX.md` (resolved via `~/.claude/url-resolver.md`) for the canonical routing table.”
+  MEMORY.md continues to hold project-specific facts and the project index; it has no routing tables.
 
 ---
 
@@ -98,17 +100,17 @@ So: **no code change to JitNeuro**; only documentation and, optionally, a separa
 
 - **Idea:** Keep one set of content that both Claude and Cursor read/write.
 - **Option 1 – Shared under `.claude/`:**  
-  Cursor is told (via rule/AGENTS.md): “JitNeuro context lives under `.claude/`: bundles, engrams, session-state, context-manifest, commands.”  
+  Cursor is told (via rule/AGENTS.md): “JitNeuro context lives under `.claude/`: bundles, engrams, session-state, commands. Routing lives in `.jit-knowledge/INDEX.md`.”
   No move; only document that Cursor uses the same paths.
 
-- **Option 2 – New vendor-neutral root:**  
+- **Option 2 – New vendor-neutral root:**
   Introduce something like `.ai/` (or `ai-context/`) and move (or symlink/copy) there:
-  - `context-manifest.md`
   - `bundles/`
   - `engrams/`
   - `session-state/`
   - `commands/` (intent docs)
   - `jitneuro.json`
+  - Note: routing stays in `.jit-knowledge/INDEX.md` regardless of this choice; do not move it into `.ai/`
 
   Then:
   - **Claude:** Keep using `.claude/` but have install script (or docs) copy/symlink from `.ai/` → `.claude/`, or point Claude at `.ai/` if it ever supports a configurable root.
@@ -122,7 +124,7 @@ Add a Cursor rule (e.g. `.cursor/rules/jitneuro-commands.mdc`) that:
 
 1. **Path:** Assumes JitNeuro root is `.claude/` (or `.ai/` if you adopt that).
 2. **Intents:** On user intent matching a known command (`/save`, `/load`, `/session`, `/bundle`, `/learn`, “checkpoint session”, “load session X”, etc.), read the corresponding `commands/<name>.md` (or the consolidated session.md, save.md, load.md, etc.) and follow its instructions.
-3. **Manifest + MEMORY:** When loading context for a task, read `context-manifest.md` and MEMORY.md (routing weights) and load the suggested bundles.
+3. **Routing + MEMORY:** When loading context for a task, read `.jit-knowledge/INDEX.md` (routing) and MEMORY.md (project facts) and load the suggested bundles. Do not read `context-manifest.md` for routing -- that file is retired.
 
 No change to the existing command markdown; they stay the single source of truth for both Claude and Cursor.
 
@@ -159,7 +161,7 @@ The JitNeuro *design* (bundles, engrams, session state, manifest, command semant
 ## 5. Minimal Checklist for “Cursor + cross-vendor”
 
 - [ ] **Document:** Cursor can use `.claude/` (or `.ai/`) content as-is; no change to bundle/engram/session-state format.
-- [ ] **Add:** One Cursor rule (or AGENTS.md block) that routes user intents to the existing command .md files and tells the agent to use manifest + MEMORY for routing.
+- [ ] **Add:** One Cursor rule (or AGENTS.md block) that routes user intents to the existing command .md files and tells the agent to use `.jit-knowledge/INDEX.md` for routing and MEMORY.md for project facts.
 - [ ] **Add:** Optional Cursor rule that injects brainstem content (from CLAUDE-brainstem.md) so Cursor has the same “always on” rules.
 - [ ] **Document:** Hooks are Claude Code–only; Cursor behavior and mitigations.
 - [ ] **Optional:** Vendor-neutral root (e.g. `.ai/`) and/or install script that writes the Cursor rule(s) so one install works for both.

--- a/docs/cursor-enablement-context.md
+++ b/docs/cursor-enablement-context.md
@@ -25,7 +25,7 @@ This document defines what must exist and be deployed in the **jitneuro** repo s
 
 - **Guardrails:** Override goals; never bypass; get current list by **reading** project/workspace `.claude/CLAUDE.md` (and repo `CLAUDE.md`). No cached copy.
 - **Save:** Trigger phrases → determine session name → gather state → write `.claude/session-state/<name>.md` → sync Hub if present → update `.current` → confirm. If compact/preserve rules needed, **read** CLAUDE.md.
-- **Load:** Resolve session (name or #) → **read** session file → **read** listed bundles → **read** `.claude/context-manifest.md` and **MEMORY.md** (routing; always read file) → update `.current` → report.
+- **Load:** Resolve session (name or #) → **read** session file → **read** listed bundles → **read** `.jit-knowledge/INDEX.md` (routing) and **MEMORY.md** (project facts; always read file) → update `.current` → report.
 - **Learn:** **Read MEMORY.md** (no cache) → health check (line counts, routing, sessions, bundles, engrams) → scan conversation for learnings → proposed changes table → approve then execute.
 - **Source-of-truth principle:** At top of rule and where relevant: CLAUDE.md and MEMORY.md are live; **read** when needed, never copy into the rule or rely on stale context.
 

--- a/docs/enterprise-isolation.md
+++ b/docs/enterprise-isolation.md
@@ -72,11 +72,11 @@ in other repos. Cross-repo sessions are not possible in isolated mode.
 
 Everything except cross-repo features:
 - /save and /load (scoped to this repo)
-- /learn (updates this repo's bundles, engrams, and MEMORY.md routing weights)
+- /learn (updates this repo's bundles, engrams; flags new routes for PR to jit-knowledge/INDEX.md)
 - /sessions (lists this repo's sessions only)
 - /orchestrate (subagents scoped to this repo)
 - Conversation logging (.logs/ inside this repo)
-- Routing weights in MEMORY.md (MEMORY.md is always per-user, not per-repo)
+- Routing from jit-knowledge/INDEX.md (shared across all users; extensions via PR)
 - Compact instructions
 - All bundle and engram management
 
@@ -140,7 +140,7 @@ team's directory. This gives shared commands with isolated context.
 ## Compliance Notes
 
 - MEMORY.md (auto-memory) is always per-user (`~/.claude/projects/`). It is NOT
-  shared between users. Each developer has their own routing weights and memory.
+  shared between users. Each developer has their own MEMORY.md. Routing is shared via jit-knowledge/INDEX.md.
 - Session state files may contain summaries of code and decisions. Include
   `.claude/session-state/` in your `.gitignore` if these should not be committed.
 - Conversation logs (`.logs/`) may contain user prompts verbatim. Always gitignore.

--- a/docs/master-session.md
+++ b/docs/master-session.md
@@ -11,7 +11,7 @@ subagent sessions scoped to individual repos.
 
 ```
 MASTER SESSION (workspace root: ~/Code/)
-  |-- Brainstem loaded: CLAUDE.md + MEMORY.md (routing weights)
+  |-- Brainstem loaded: CLAUDE.md + MEMORY.md (project index) + jit-knowledge/INDEX.md (routing)
   |-- Context: ~3-4% used for infrastructure
   |-- Role: route, delegate, summarize, checkpoint
   |
@@ -42,7 +42,7 @@ the context it needs. Cross-repo dependencies are tracked in one place.
 
 ## Master Session Responsibilities
 
-1. **Route tasks** to the right repo + bundles using routing weights
+1. **Route tasks** to the right repo + bundles using jit-knowledge/INDEX.md routing
 2. **Track cross-repo state** in session-state (which repos, which stories, which branch)
 3. **Enforce ordering** -- API must deploy before FE can test against it
 4. **Collect summaries** -- never load full code diffs into master context

--- a/docs/memory-maintenance.md
+++ b/docs/memory-maintenance.md
@@ -47,18 +47,18 @@ These load only when MEMORY.md references them, keeping context costs low.
 
 ### 3. JitNeuro /learn (bundles, engrams, routing)
 
-**Location:** `.claude/bundles/`, `.claude/engrams/`, MEMORY.md routing section
-**Loaded:** On-demand by routing weights or manual bundle load
+**Location:** `.claude/bundles/`, `.claude/engrams/`, `jit-knowledge/INDEX.md` (routing)
+**Loaded:** On-demand by INDEX.md routing or manual bundle load
 **Created by:** `/learn` command evaluation
-**Updated by:** `/learn` (with owner approval)
+**Updated by:** `/learn` (with owner approval); routing changes via PR to jit-knowledge
 
 /learn captures domain knowledge and project context:
 - **Bundles** -- cross-project domain knowledge ("how to deploy", "API patterns")
 - **Engrams** -- per-project deep context ("what this repo is, how it works")
-- **Routing weights** -- patterns mapping task types to bundle combinations
+- **Routing** -- lives exclusively in `jit-knowledge/INDEX.md`; /learn flags missing routes and prompts you to open a PR
 
 **Maintenance:** `/learn` includes a health check that flags oversized bundles (280+ lines),
-missing engrams, stale sessions, and broken routing weights. Run it at session boundaries.
+missing engrams, stale sessions, and routes that may need updating in INDEX.md. Run it at session boundaries.
 
 ## Where Things Go (Decision Tree)
 
@@ -90,7 +90,7 @@ Is this a behavioral correction from the owner?
 |---------|---------|-----|
 | Same guidance in feedback_* and rules/ | Auto-memory saved what was already a rule | Delete the feedback_* file |
 | A feedback_* that says "always" or "never" | Universal instruction stored as situational memory | Promote to rules/, delete feedback_* |
-| MEMORY.md has "how to deploy" instructions | Domain knowledge in the index file | Extract to a bundle, replace with routing pointer |
+| MEMORY.md has "how to deploy" instructions | Domain knowledge in the index file | Extract to a bundle; add route to jit-knowledge/INDEX.md via PR |
 | A bundle has owner-specific names or preferences | Project-specific content in a cross-project file | Move to the project's engram or rules/ |
 | An engram has process instructions | Behavioral rule stored as project context | Move to rules/ (global) or .claude/rules/ (project) |
 
@@ -99,18 +99,18 @@ Is this a behavioral correction from the owner?
 When JitNeuro releases updates, the install script touches:
 - `<repo>/.claude/commands/` -- slash command templates (overwritten)
 - `<repo>/.claude/CLAUDE.md` -- project guardrails template (overwritten if using template)
-- Templates in `.claude/` workspace -- bundles, engrams, context manifest
+- Templates in `.claude/` workspace -- bundles, engrams
 
 The install script does NOT touch:
 - `~/.claude/rules/` -- owner's global rules (never overwritten)
 - `~/.claude/projects/*/memory/` -- auto-memory (never overwritten)
-- MEMORY.md -- routing weights and index (never overwritten)
+- MEMORY.md -- project index and business facts (never overwritten; routing lives in jit-knowledge/INDEX.md)
 - `.claude/jitneuro-settings.json` -- runtime settings (never overwritten)
 
 **Safe upgrade pattern:**
 1. Run `jitneuro install` (overwrites templates only)
 2. Run `/learn` or `/health` to verify memory system health after upgrade
-3. If new commands or conventions were added, /learn will flag missing routing weights
+3. If new commands or conventions were added, /learn will flag routes that may need updating in jit-knowledge/INDEX.md
 
 ## MEMORY.md Remediation (When It Gets Too Big)
 
@@ -153,7 +153,7 @@ See `templates/memory/detail-index.md` for the template. Group entries by domain
 
 **When:** MEMORY.md has paragraphs of domain knowledge (infrastructure details, deployment procedures, API patterns). These are facts that don't need to load every session.
 
-**Fix:** Move the section to a bundle (`.claude/bundles/<domain>.md`). Replace in MEMORY.md with a routing weight entry so it loads on-demand when the topic comes up.
+**Fix:** Move the section to a bundle (`.claude/bundles/<domain>.md`). Add a route to `jit-knowledge/INDEX.md` so the bundle loads on-demand when the topic comes up. Remove the section from MEMORY.md entirely.
 
 Before (20 lines in MEMORY.md):
 ```
@@ -163,12 +163,13 @@ Before (20 lines in MEMORY.md):
 - Deployment steps are...
 ```
 
-After (1 line in MEMORY.md routing weights):
+After (bundle created; route added to jit-knowledge/INDEX.md via PR):
 ```
+# jit-knowledge/INDEX.md
 - Deploy / server / VM / container -> [infrastructure]
 ```
 
-The bundle holds the full detail. Routing weights ensure it loads when relevant.
+The bundle holds the full detail. INDEX.md routing ensures it loads when relevant. MEMORY.md has no routing entries.
 
 ### Strategy 3: Extract project detail to engrams
 
@@ -227,7 +228,7 @@ Split into work areas:
 
 Each workspace has:
 - Its own `.claude/` with MEMORY.md, bundles, engrams
-- Its own routing weights scoped to relevant domains
+- Routes in jit-knowledge/INDEX.md (a PR per new route -- shared single source)
 - Smaller, focused context that fits within 200 lines
 - Cross-workspace facts go in `~/.claude/rules/` (loads everywhere)
 

--- a/docs/ralph-integration.md
+++ b/docs/ralph-integration.md
@@ -88,7 +88,7 @@ What kind of work is this?
 ```
 JITNEURO (memory layer)              RALPH (execution layer)
   |                                    |
-  |-- MEMORY.md (routing weights)      |-- config.toml (agent config)
+  |-- MEMORY.md (project index)        |-- config.toml (agent config)
   |-- Bundles (domain knowledge)       |-- prd.json (stories + AC)
   |-- Engrams (project context)        |-- iterations/ (execution logs)
   |-- Session state (checkpoints)      |-- reports/ (results)
@@ -107,7 +107,7 @@ JITNEURO (memory layer)              RALPH (execution layer)
 User: "Plan Sprint-UserAuth-001"
 
 Master session:
-  - Loads bundles: [sprint, api] via routing weights
+  - Loads bundles: [sprint, api] (via jit-knowledge/INDEX.md routing)
   - Loads engram: aifs-api.md (project context)
   - Builds spec in .ralph-tui/specs/Sprint-UserAuth-001.md
   - Creates stories in .ralph-tui/tasks/Sprint-UserAuth-001/backlog.md
@@ -238,7 +238,7 @@ Ralph finishes. Back in master session:
 User: "Ralph done. Run US-HER review."
 
 Master session:
-  - Loads bundles: [sprint, api] (routing weights)
+  - Loads bundles: [sprint, api] (via jit-knowledge/INDEX.md routing)
   - Loads engram: aifs-api.md
   - Reads Ralph's output: progress.md, reports/, git log
   - Evaluates from 4 personas (architect, maintenance, reliability, security)
@@ -256,7 +256,7 @@ User: "Run /learn"
   - Did Ralph discover new patterns? (update engram)
   - Did the sprint add new routes/files? (update engram)
   - Did the review reveal bundle gaps? (update bundle)
-  - Did routing weights work? (update MEMORY.md if not)
+  - Did routing work? (suggest PR to jit-knowledge/INDEX.md if a route was missing)
   - System health check: all files within limits?
 ```
 

--- a/docs/routing-vs-semantic-memory.md
+++ b/docs/routing-vs-semantic-memory.md
@@ -2,6 +2,8 @@
 
 Why JitNeuro uses explicit routing weights instead of vector embeddings for context loading, and what that means for precision, auditability, and token efficiency.
 
+> **Single-source note (2026-05-12):** Routing weights now live exclusively in `jit-knowledge/INDEX.md` (the canonical single source). The design philosophy described here -- keyword-to-bundle mappings, deterministic precision, /learn-driven improvement -- remains unchanged. What changed is WHERE those mappings are stored: not in MEMORY.md or local files, but in INDEX.md as a shared versioned source. Per-machine resolution uses `~/.claude/url-resolver.md`.
+
 ## The Problem Both Solve
 
 Given a user request, which context should the AI assistant have?

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -195,14 +195,21 @@ Claude Code will read the template, extract domain-specific content from your ex
 
 Claude Code will copy the template, rename it, and walk you through what to add. Keep under 180 lines. Include: key files, commands, conventions, gotchas. Exclude: anything Claude can infer from reading the code.
 
-### Update the Manifest and Routing
+### Register Bundles with the Canonical Router
 
+Routing lives in `jit-knowledge/INDEX.md` -- the single source of truth for all task-keyword to bundle mappings. To make a new bundle load automatically:
+
+1. Open a PR to `dstolts/jit-knowledge` adding a route line to `INDEX.md`:
+   `- <trigger phrase>  -> [your-bundle-name]`
+2. Once merged, your consuming system picks it up on the next `jit-knowledge` submodule pull.
+
+For local-only routes (experimental, not recommended long-term), ask Claude Code:
 ```
-> "Add my new bundles to the context manifest and set up routing weights in MEMORY.md
-   so they load automatically for the right tasks."
+> "Add a temporary routing entry for my-bundle to .jitneuro/engrams/context.md
+   and note it should be promoted to jit-knowledge/INDEX.md via PR."
 ```
 
-Claude Code will update context-manifest.md with your bundles and add routing weights to MEMORY.md based on the task patterns you describe.
+Do NOT add routing entries to `context-manifest.md` or `MEMORY.md`; those surfaces no longer carry routing tables.
 
 ### Add Compact Instructions to CLAUDE.md
 
@@ -268,7 +275,7 @@ See [concepts.md](concepts.md) for detailed explanation with examples.
 | "bash not found" on Windows | Install Git for Windows. Installer detects paths automatically. |
 | settings.local.json parse error | Installer skips merge on parse failure. Fix JSON and re-run. |
 | Claude ignores bundle content | Bundle too long (over 180 lines) or conflicting with CLAUDE.md. |
-| Wrong bundles loaded | Update routing weights in manifest/MEMORY.md. |
+| Wrong bundles loaded | Open a PR to jit-knowledge/INDEX.md to add or correct the route mapping. |
 | Context still fills up | Use agents more aggressively, save/clear more often. |
 | /load loads stale state | Check session date with `/sessions`. |
 | Interrupted install | No `jitneuro.json` in `.claude/` = incomplete. Re-run installer. |

--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -7,7 +7,7 @@ Detailed technical reference for JitNeuro internals. For the quick version, see 
 JitNeuro implements the **DOE (Directive Orchestration Execution)** framework -- a three-layer pattern for AI-assisted development:
 
 - **Directive** -- Owner gives short, high-level instructions. "Score all blog posts." "Audit the repos." "Fix the auth bug." No step-by-step hand-holding.
-- **Orchestration** -- Claude determines the approach: which bundles to load, which agents to spawn, what order to execute, how to split work across repos. The orchestration layer reads routing weights, context manifests, and session state to make these decisions.
+- **Orchestration** -- Claude determines the approach: which bundles to load, which agents to spawn, what order to execute, how to split work across repos. The orchestration layer reads `jit-knowledge/INDEX.md` (routing table) and session state to make these decisions.
 - **Execution** -- Agents do the work. Workers read files, write code, run tests, score content, draft responses. Results flow up as thin summaries. Detail stays in files on disk.
 
 The owner does the $10K/hr work (judgment, priorities, approval). The AI does the $10/hr work (research, coding, analysis, content drafting, task execution). JitNeuro is the memory and orchestration layer that makes this possible across sessions, repos, and teams.
@@ -40,9 +40,10 @@ For architecture diagrams and the neural network mapping, see [architecture.md](
 
 ```
 LONG-TERM MEMORY (disk -- survives all sessions)
-  |-- MEMORY.md            learned patterns + routing weights
+  |-- MEMORY.md            project index + business facts
   |-- bundles/             domain knowledge, loaded on-demand
   |-- engrams/             per-project deep context (updated by /learn)
+  |-- .jit-knowledge/      routing table -- jit-knowledge/INDEX.md (single source)
 
 WORKING MEMORY (context window -- limited capacity)
   |-- CLAUDE.md            core rules (always loaded, minimal)
@@ -65,9 +66,10 @@ workspace-root/
   |   |-- hooks/              hook scripts (6 lifecycle hooks)
   |   |-- rules/              path-scoped rules (optional)
   |   |-- session-state/      session checkpoints
-  |   |-- context-manifest.md bundle index + routing
   |   |-- jitneuro.json       version, hooks config, settings
   |   |-- settings.local.json Claude Code hooks configuration
+  |-- .jit-knowledge/         jit-knowledge submodule (INDEX.md = routing table)
+  |-- ~/.claude/url-resolver.md  GitHub URL -> local path map (machine-specific)
   |-- repo-a/
   |-- repo-b/
 ```

--- a/install.ps1
+++ b/install.ps1
@@ -114,13 +114,24 @@ foreach ($cmdFile in $cmdTemplates) {
 }
 Write-Host "  ($CmdCount commands installed)"
 
-# Copy context-manifest (don't overwrite)
-$manifest = Join-Path $Target "context-manifest.md"
-if (-not (Test-Path $manifest)) {
-    Copy-Item (Join-Path $Templates "context-manifest.md") $manifest
-    Write-Host "Created context-manifest.md"
+# Routing now lives in jit-knowledge/INDEX.md -- do NOT seed context-manifest.md with routing tables.
+# If a stale context-manifest.md exists from a prior install, leave it untouched (do not overwrite or delete).
+# Users can remove it by running: jit-knowledge/scripts/cleanup-old-routing.ps1
+$staleManifest = Join-Path $Target "context-manifest.md"
+if (Test-Path $staleManifest) {
+    Write-Host "NOTE: Legacy context-manifest.md found at $staleManifest" -ForegroundColor Yellow
+    Write-Host "      Routing now lives in jit-knowledge/INDEX.md. Run cleanup-old-routing.ps1 to retire it." -ForegroundColor Yellow
+}
+
+# Scaffold url-resolver.md in user home .claude (machine-specific, gitignored)
+$UserClaude = Join-Path $env:USERPROFILE ".claude"
+$UrlResolver = Join-Path $UserClaude "url-resolver.md"
+if (-not (Test-Path $UrlResolver)) {
+    if (-not (Test-Path $UserClaude)) { New-Item -ItemType Directory -Path $UserClaude -Force | Out-Null }
+    Copy-Item (Join-Path $Templates "url-resolver.md") $UrlResolver
+    Write-Host "Created ~/.claude/url-resolver.md -- add your jit-knowledge local path to enable routing"
 } else {
-    Write-Host "Skipped context-manifest.md (already exists)" -ForegroundColor Yellow
+    Write-Host "Skipped url-resolver.md (already exists)" -ForegroundColor Yellow
 }
 
 # Copy example bundle if empty
@@ -449,9 +460,10 @@ Write-Host "JitNeuro v$Version installed to: $Target" -ForegroundColor Green
 Write-Host ""
 Write-Host "Next steps:"
 Write-Host "  1. CLOSE AND REOPEN Claude Code (commands load at session start)" -ForegroundColor Yellow
-Write-Host "  2. Run /verify to confirm everything is working"
-Write-Host "  3. Run /onboard <repo> to set up context for your repos"
-Write-Host "  4. Create bundles for your domains in $Target\bundles\"
+Write-Host "  2. Edit ~/.claude/url-resolver.md -- add the local path to your jit-knowledge clone"
+Write-Host "  3. Run /verify to confirm everything is working"
+Write-Host "  4. Run /onboard <repo> to set up context for your repos"
+Write-Host "  5. Create bundles for your domains in $Target\bundles\"
 Write-Host ""
 Write-Host "*** You MUST restart Claude Code for slash commands to take effect. ***" -ForegroundColor Red
 Write-Host ""

--- a/install.sh
+++ b/install.sh
@@ -118,12 +118,23 @@ for cmd_file in "$TEMPLATES/commands/"*.md; do
 done
 echo "  ($CMD_COUNT commands installed)"
 
-# Copy templates (don't overwrite existing)
-if [ ! -f "$TARGET/context-manifest.md" ]; then
-  cp "$TEMPLATES/context-manifest.md" "$TARGET/context-manifest.md"
-  echo "Created context-manifest.md"
+# Routing now lives in jit-knowledge/INDEX.md -- do NOT seed context-manifest.md with routing tables.
+# If a stale context-manifest.md exists from a prior install, leave it untouched (do not overwrite or delete).
+# Users can remove it by running: jit-knowledge/scripts/cleanup-old-routing.sh
+if [ -f "$TARGET/context-manifest.md" ]; then
+  echo "NOTE: Legacy context-manifest.md found at $TARGET/context-manifest.md"
+  echo "      Routing now lives in jit-knowledge/INDEX.md. Run cleanup-old-routing.sh to retire it."
+fi
+
+# Scaffold url-resolver.md in user home .claude (machine-specific, gitignored)
+USER_CLAUDE="$HOME/.claude"
+URL_RESOLVER="$USER_CLAUDE/url-resolver.md"
+if [ ! -f "$URL_RESOLVER" ]; then
+  mkdir -p "$USER_CLAUDE"
+  cp "$TEMPLATES/url-resolver.md" "$URL_RESOLVER"
+  echo "Created ~/.claude/url-resolver.md -- add your jit-knowledge local path to enable routing"
 else
-  echo "Skipped context-manifest.md (already exists)"
+  echo "Skipped url-resolver.md (already exists)"
 fi
 
 # Copy example bundle if bundles dir is empty
@@ -374,9 +385,10 @@ echo "JitNeuro v$VERSION installed to: $TARGET"
 echo ""
 echo "Next steps:"
 echo "  1. CLOSE AND REOPEN Claude Code (commands load at session start)"
-echo "  2. Run /verify to confirm everything is working"
-echo "  3. Run /onboard <repo> to set up context for your repos"
-echo "  4. Create bundles for your domains in $TARGET/bundles/"
+echo "  2. Edit ~/.claude/url-resolver.md -- add the local path to your jit-knowledge clone"
+echo "  3. Run /verify to confirm everything is working"
+echo "  4. Run /onboard <repo> to set up context for your repos"
+echo "  5. Create bundles for your domains in $TARGET/bundles/"
 echo ""
 echo "*** You MUST restart Claude Code for slash commands to take effect. ***"
 echo ""

--- a/templates/.archive/context-manifest.md
+++ b/templates/.archive/context-manifest.md
@@ -1,0 +1,58 @@
+# ARCHIVED 2026-05-12 -- routing moved to jit-knowledge/INDEX.md per Step 6 plan
+# Original content preserved below for reference. Do not load -- use INDEX.md instead.
+
+---
+
+# Context Manifest
+
+This file indexes all available context bundles and tracks session state.
+The orchestrator reads this to determine which bundles to load for a given task.
+
+## Always Load (Brainstem)
+These load automatically at session start via CLAUDE.md:
+- `~/.claude/CLAUDE.md` (global rules)
+- `.claude/CLAUDE.md` (project rules)
+- `MEMORY.md` (first 200 lines -- routing weights)
+
+## Available Bundles
+
+| Bundle | Path | Domain | Lines | Last Used |
+|--------|------|--------|-------|-----------|
+| example | .claude/bundles/example.md | Example template | ~30 | never |
+
+<!-- Add your bundles here. Keep under 180 lines each. -->
+<!-- Example entries:
+| deploy    | .claude/bundles/deploy.md    | CI/CD, containers, environments | ~60 | 2026-03-09 |
+| api       | .claude/bundles/api.md       | API design, auth, error handling | ~50 | 2026-03-09 |
+| sprint    | .claude/bundles/sprint.md    | Sprint protocol, task format     | ~70 | 2026-03-08 |
+| testing   | .claude/bundles/testing.md   | Test strategy, commands, fixtures | ~40 | 2026-03-07 |
+-->
+
+## Routing Weights
+
+Patterns that map task types to bundle combinations.
+Update these as you learn which bundles co-activate:
+
+```
+- Default task         -> bundles: []  (brainstem only)
+<!-- Example routing weights:
+- Deploy tasks         -> bundles: [deploy, infra]
+- API development      -> bundles: [api, testing]
+- Sprint execution     -> bundles: [sprint, cross-repo]
+- Bug investigation    -> bundles: [api, testing, deploy]
+- Documentation        -> bundles: []  (brainstem sufficient)
+-->
+```
+
+## Session State
+
+Updated by /save command. Read by /load command after /clear.
+
+```
+active_bundles: []
+current_task: none
+modified_files: []
+pending_decisions: []
+next_steps: []
+key_findings: []
+```

--- a/templates/.archive/rules-routing-weights.md
+++ b/templates/.archive/rules-routing-weights.md
@@ -1,0 +1,42 @@
+# ARCHIVED 2026-05-12 -- routing moved to jit-knowledge/INDEX.md per Step 6 plan
+
+---
+
+# Routing Weights
+
+Load context bundles based on task keywords. Each entry maps trigger phrases to one or more bundle names. When a user request matches a trigger, the listed bundles are loaded to provide domain-specific context.
+
+## Pattern
+
+```
+- <trigger phrases>  -> [bundle-name]
+- <trigger phrases>  -> [bundle-a, bundle-b]
+```
+
+## Example Routes
+
+```
+- Deploy / server / container / VM       -> [infrastructure]
+- API / endpoint / route / auth          -> [api-patterns]
+- Blog / post / publish / content        -> [content]
+- Sprint / story / prd / backlog         -> [sprint-workflow]
+- Test / spec / coverage / assertion     -> [testing]
+- Bug / error / debug / investigate      -> [infrastructure, integrations]
+```
+
+## How It Works
+
+1. AI scans the user's request for trigger keywords
+2. Matching bundles are loaded from the bundles directory
+3. Multiple bundles can load simultaneously for cross-domain tasks
+4. Unmatched requests use base context only (no extra bundles)
+
+## Tips
+
+- Group related keywords on the same line (e.g., "deploy / server / container")
+- Use multi-bundle routes for tasks that span domains (e.g., "cross-repo sprint -> [sprint-workflow, infrastructure]")
+- Keep trigger phrases short -- 2-4 words per phrase is ideal
+- Order routes from most specific to most general
+- Add a "Full manifest" reference so AI can discover all available bundles
+
+Full manifest: .claude/context-manifest.md

--- a/templates/CLAUDE-brainstem.md
+++ b/templates/CLAUDE-brainstem.md
@@ -79,8 +79,7 @@ From any repo, Claude has full read/write access to:
 - `[workspace]/.claude/bundles/` -- shared domain knowledge
 - `[workspace]/.claude/engrams/` -- shared project context
 - `[workspace]/.claude/session-state/` -- shared session checkpoints
-- `[workspace]/.claude/context-manifest.md` -- bundle index and routing
-- MEMORY.md auto-memory (routing weights, project index)
+- MEMORY.md auto-memory (project index)
 -->
 
 ## Feature Discovery
@@ -92,9 +91,9 @@ When the user expresses a need, wish, or frustration ("I wish...", "can we...", 
 - Cognition: `.claude/cognition/personas.md` (16 expert personas, always active)
 - Cognition: `.claude/cognition/owner-persona.md` (personal overlay, if exists)
 - Decisions: `.claude/cognition/decisions/` (structured decision frameworks)
-- Manifest: `.claude/context-manifest.md` (bundle index + routing)
+- Routing: `.jit-knowledge/INDEX.md` (single source -- resolved via `~/.claude/url-resolver.md`)
 - Session state: `.claude/session-state/` (one file per named session)
-- Memory: Check MEMORY.md routing weights for task-to-bundle mapping
+- Memory: Check MEMORY.md for project facts and project index
 
 ## Compact Instructions
 When compacting, always preserve:
@@ -117,7 +116,7 @@ When conversation_log is "on" in session-state.md:
 <!-- Only paths Claude needs constantly. Domain paths go in bundles. -->
 | Path | Purpose |
 |------|---------|
-| `.claude/context-manifest.md` | Bundle index and routing |
+| `.jit-knowledge/INDEX.md` | Routing table (single source; resolved via url-resolver.md) |
 | `.claude/session-state/` | Session checkpoints (one per task) |
 | `.claude/bundles/` | Domain knowledge bundles |
 | `.claude/engrams/` | Per-project deep context |

--- a/templates/commands/bundle.md
+++ b/templates/commands/bundle.md
@@ -52,15 +52,14 @@ c. **If no source material found:** Ask the user what this bundle should cover.
 
 d. **Present the draft** and ask for approval before writing.
 
-e. **On approval:** Write to `.claude/bundles/<name>.md`, update
-   `context-manifest.md` (add row to Available Bundles table), and suggest
-   routing weight entries for MEMORY.md.
+e. **On approval:** Write to `.claude/bundles/<name>.md` and suggest
+   opening a PR to `jit-knowledge/INDEX.md` to add the routing entry for this bundle.
 
 ### 4. Without arguments (`/bundle`):
 
 a. Scan `.claude/bundles/` for actual files. Count lines in each.
-b. Read `context-manifest.md` and compare -- flag bundles that exist on disk
-   but aren't in the manifest, or manifest entries with no matching file.
+b. Read `.jit-knowledge/INDEX.md` (via `~/.claude/url-resolver.md`) and compare -- flag bundles that exist on disk
+   but have no routing entry in INDEX.md.
 c. Present:
 
 ```
@@ -96,12 +95,11 @@ If a bundle is over 280 lines, or the user asks to split:
 1. Identify natural subdomain boundaries in the content
 2. Propose split: `<name>-a.md` and `<name>-b.md` with clear names
 3. Show what goes where
-4. On approval: write both files, archive original, update manifest,
-   update routing weights to reference both
+4. On approval: write both files, archive original, suggest PR to jit-knowledge/INDEX.md
+   to update routing to reference both split bundles
 
 ## Important
 - Always ask before writing or modifying bundle files.
 - Target: under 280 lines. Claude reads the full file regardless of length, but shorter bundles load faster and waste fewer tokens when loaded for the wrong task.
 - One bundle = one domain. If a bundle covers two unrelated things, split it.
-- After any write, update context-manifest.md to match reality.
-- Routing weights live in MEMORY.md -- suggest entries but let the user approve.
+- Routing entries live in `jit-knowledge/INDEX.md` -- suggest a PR but do not write locally.

--- a/templates/commands/enterprise.md
+++ b/templates/commands/enterprise.md
@@ -83,7 +83,7 @@ Store rules at the lowest level possible, closest to where they apply.
 - .claude/rules/*.md: path-scoped rules (load automatically per file type)
 - .claude/bundles/*.md: domain knowledge (load on demand by task)
 - .claude/engrams/*.md: project context (load on demand per repo)
-- MEMORY.md: routing weights + index (first 200 lines)
+- MEMORY.md: project index + business facts (first 200 lines; routing lives in jit-knowledge/INDEX.md)
 Don't put schema rules in CLAUDE.md. Put them in rules/schema.md.
 Don't put deploy commands in CLAUDE.md. Put them in rules/deployment.md.
 ```

--- a/templates/commands/health.md
+++ b/templates/commands/health.md
@@ -72,8 +72,8 @@ You are running a JitNeuro deep health check. Read every file listed below FROM 
 **Bundles** (.claude/bundles/)
 - List all bundles with line counts.
 - OK < 230, WARN 230-279, OVER 280+. Soft limit -- report only, do not auto-trim.
-- Flag bundles referenced in routing weights that don't exist.
-- Flag bundles that exist but have no routing weight entry.
+- Flag bundles referenced in INDEX.md routing that don't exist on disk.
+- Flag bundles on disk that have no routing entry in INDEX.md (suggest PR to jit-knowledge).
 
 **Engrams** (.claude/engrams/)
 - List all engrams with line counts.
@@ -86,14 +86,11 @@ You are running a JitNeuro deep health check. Read every file listed below FROM 
 - Flag sessions older than 14 days as EXPIRED.
 - Count total (more than 10 = CLUTTER).
 
-**Routing Weights** (in MEMORY.md)
-- Check routing entries point to bundles/engrams that exist.
-- Check for bundles that exist but have no routing entry.
-
-**Context Manifest** (.claude/context-manifest.md)
-- Verify it lists all bundles that actually exist.
-- Flag bundles in manifest that don't exist on disk.
-- Flag bundles on disk not listed in manifest.
+**Routing** (jit-knowledge/INDEX.md via url-resolver.md)
+- Check `~/.claude/url-resolver.md` exists and has an entry for jit-knowledge.
+- Read INDEX.md (via url-resolver) and verify routing entries point to bundles that exist in `.claude/bundles/`.
+- Flag bundles in `.claude/bundles/` that have no routing entry in INDEX.md (suggest PR to jit-knowledge).
+- If url-resolver is missing or INDEX.md is unreachable, flag as WARNING with setup instructions.
 
 **Hub.md** (per-repo task durability)
 - Resolve current session from heartbeats.

--- a/templates/commands/onboard.md
+++ b/templates/commands/onboard.md
@@ -132,8 +132,8 @@ Review and approve? (all / pick by number / edit first)
 
 - Write approved files
 - Add repo to MEMORY.md project table (if not already there)
-- Add routing weight entry if the repo maps to a clear domain
-- Update context-manifest.md if new bundles are needed
+- Suggest PR to `jit-knowledge/INDEX.md` if a new routing entry is needed for this repo's domain
+- Add bundle files to `.claude/bundles/` if new bundles are needed; routing goes via PR to INDEX.md
 
 ### Step 6: Verify
 

--- a/templates/commands/orchestrate.md
+++ b/templates/commands/orchestrate.md
@@ -18,9 +18,9 @@ No manual /clear or reload needed. No new sessions to open.
 When a task is received:
 
 1. **Classify the task** -- determine which domain(s) it touches:
-   - Read `.claude/context-manifest.md` for available bundles
-   - Check routing weights in the manifest (or MEMORY.md) for known patterns
-   - If no routing weight exists, infer from the task description
+   - Read `.jit-knowledge/INDEX.md` (via `~/.claude/url-resolver.md`) for routing patterns
+   - Scan `.claude/bundles/` for available bundles on this install
+   - If no routing entry exists in INDEX.md, infer from the task description
 
 2. **Decide execution strategy:**
 
@@ -68,12 +68,12 @@ When a task is received:
    - Only read SUMMARY_DOC if you need detail beyond the status and file list
    - If BLOCKED: answer the question and re-dispatch via SendMessage
    - Update session-state.md with results
-   - If new routing patterns discovered, note for MEMORY.md update
+   - If new routing patterns discovered, note for jit-knowledge PR
    - Report to user: what was done, files changed, what's next
 
-5. **Update routing weights** if a new pattern emerged:
-   - "Task type X needed bundles [A, B] -- adding to routing weights"
-   - Update context-manifest.md or MEMORY.md at session end
+5. **Update routing** if a new pattern emerged:
+   - "Task type X needed bundles [A, B] -- suggest PR to jit-knowledge/INDEX.md"
+   - Routing lives in INDEX.md; do not write to context-manifest.md or MEMORY.md
 
 ## Routing Decision Table
 
@@ -91,4 +91,4 @@ When a task is received:
 - Never load all bundles into main context "just in case"
 - When in doubt, use an agent (isolated context is always safer)
 - Failed agent? Retry with additional bundles, not more main context
-- Update routing weights after discovering new co-activation patterns
+- When new co-activation patterns are discovered, suggest a PR to jit-knowledge/INDEX.md to add the route

--- a/templates/commands/session.md
+++ b/templates/commands/session.md
@@ -271,7 +271,7 @@ BLOCKED: [count] items needing attention
 
 4. **Read active bundles** listed in session state (only those listed)
 
-5. **Read `.claude/context-manifest.md`** for bundle awareness
+5. **Read `.jit-knowledge/INDEX.md`** (via `~/.claude/url-resolver.md`) for routing and bundle awareness
 
 6. **Write "my current"** (session name).
 

--- a/templates/commands/verify.md
+++ b/templates/commands/verify.md
@@ -24,7 +24,7 @@ When invoked as `/verify`:
    | 6 | Hook events | Event names match Claude Code events (PreCompact, SessionStart, PreToolUse, SessionEnd) | All valid | Unknown event name | -- |
    | 7 | Bundles | Check .claude/bundles/ has files | Has bundles | Only example.md | Empty |
    | 8 | Engrams | Check .claude/engrams/ has files | Has engrams | Only example.md | Empty |
-   | 9 | Context manifest | Check .claude/context-manifest.md exists | Exists | -- | Missing |
+   | 9 | URL resolver | Check ~/.claude/url-resolver.md exists and has a jit-knowledge entry | Entry present | File missing | No jit-knowledge entry |
 
 3. **Check config values:**
    - If `preCompactBehavior` is "warn": flag as YELLOW ("block is recommended to prevent silent context loss")

--- a/templates/context-manifest.md
+++ b/templates/context-manifest.md
@@ -1,53 +1,30 @@
-# Context Manifest
+# Context Manifest -- DEPRECATED TEMPLATE
 
-This file indexes all available context bundles and tracks session state.
-The orchestrator reads this to determine which bundles to load for a given task.
+This template file is deprecated as of 2026-05-12 (Step 6 Layer B sweep).
 
-## Always Load (Brainstem)
-These load automatically at session start via CLAUDE.md:
-- `~/.claude/CLAUDE.md` (global rules)
-- `.claude/CLAUDE.md` (project rules)
-- `MEMORY.md` (first 200 lines -- routing weights)
+The context-manifest.md pattern taught local routing. Routing now lives exclusively in:
 
-## Available Bundles
+  https://github.com/dstolts/jit-knowledge/blob/main/INDEX.md
 
-| Bundle | Path | Domain | Lines | Last Used |
-|--------|------|--------|-------|-----------|
-| example | .claude/bundles/example.md | Example template | ~30 | never |
+## What to do instead
 
-<!-- Add your bundles here. Keep under 180 lines each. -->
-<!-- Example entries:
-| deploy    | .claude/bundles/deploy.md    | CI/CD, containers, environments | ~60 | 2026-03-09 |
-| api       | .claude/bundles/api.md       | API design, auth, error handling | ~50 | 2026-03-09 |
-| sprint    | .claude/bundles/sprint.md    | Sprint protocol, task format     | ~70 | 2026-03-08 |
-| testing   | .claude/bundles/testing.md   | Test strategy, commands, fixtures | ~40 | 2026-03-07 |
--->
+When setting up a new repo with JitNeuro:
 
-## Routing Weights
+1. Clone or add jit-knowledge as a submodule: `.jit-knowledge/`
+2. Set up `~/.claude/url-resolver.md` with the repo URL -> local path map
+3. In your repo's CLAUDE.md, reference INDEX.md for routing:
+   `# Routing: see .jit-knowledge/INDEX.md (resolved via ~/.claude/url-resolver.md)`
 
-Patterns that map task types to bundle combinations.
-Update these as you learn which bundles co-activate:
+The INDEX.md is the single source of truth for all task-keyword -> bundle mappings.
+Do NOT create a local routing-weights.md or context-manifest.md with routing tables.
 
-```
-- Default task         -> bundles: []  (brainstem only)
-<!-- Example routing weights:
-- Deploy tasks         -> bundles: [deploy, infra]
-- API development      -> bundles: [api, testing]
-- Sprint execution     -> bundles: [sprint, cross-repo]
-- Bug investigation    -> bundles: [api, testing, deploy]
-- Documentation        -> bundles: []  (brainstem sufficient)
--->
-```
+## Bundle catalog (non-routing sections)
 
-## Session State
+If you need a local index of available bundles without routing, use your repo's
+`.jitneuro/bundles/` directory listing. The engram at `.jitneuro/engrams/context.md`
+should describe which bundles are available for this repo.
 
-Updated by /save command. Read by /load command after /clear.
+## Archive
 
-```
-active_bundles: []
-current_task: none
-modified_files: []
-pending_decisions: []
-next_steps: []
-key_findings: []
-```
+The original context-manifest.md template is preserved at:
+  `templates/.archive/context-manifest.md`

--- a/templates/cursor/README.md
+++ b/templates/cursor/README.md
@@ -26,8 +26,8 @@ mkdir -p .cursor/rules
 cp jitneuro/templates/cursor/rules/jitneuro-intents.mdc .cursor/rules/
 ```
 
-Ensure your `.claude/` (or workspace `.claude/`) has the usual layout: `session-state/`, `bundles/`, `engrams/`, `context-manifest.md`. The rule references those paths.
+Ensure your `.claude/` (or workspace `.claude/`) has the usual layout: `session-state/`, `bundles/`, `engrams/`. The rule references those paths. Routing comes from `.jit-knowledge/INDEX.md` (resolved via `~/.claude/url-resolver.md`), not from `context-manifest.md`.
 
 ## Paths
 
-The rule uses `.claude/` for session-state, bundles, engrams, and manifest. Resolve it from the workspace root or the project root that actually contains `.claude/` (e.g. in a multi-root workspace, the root that has `session-state/`).
+The rule uses `.claude/` for session-state, bundles, and engrams. Routing uses `.jit-knowledge/INDEX.md`. Resolve `.claude/` from the workspace root or the project root that actually contains it (e.g. in a multi-root workspace, the root that has `session-state/`).

--- a/templates/memory/README.md
+++ b/templates/memory/README.md
@@ -16,14 +16,14 @@ MEMORY.md has a hard 200-line limit (Claude Code silently truncates beyond that)
 The full searchable table with descriptions, grouped by type (user, project, reference, feedback). When feedback grows large, subdivide by domain (e.g., "Feedback -- N8N", "Feedback -- Salesforce").
 
 ### Adding new memories
-When creating a new feedback/project/reference file, add the entry to `detail-index.md`, NOT to MEMORY.md. MEMORY.md only holds facts that Claude needs every session (business context, project index, routing weights). Detail files are loaded on-demand.
+When creating a new feedback/project/reference file, add the entry to `detail-index.md`, NOT to MEMORY.md. MEMORY.md holds facts Claude needs every session (business context, project index). Routing lives in `jit-knowledge/INDEX.md`. Detail files are loaded on-demand.
 
 ## What goes where
 
 | Content | Location | Why |
 |---------|----------|-----|
-| Business facts, project index, routing weights | MEMORY.md | Needed every session |
+| Business facts, project index | MEMORY.md | Needed every session |
 | Individual feedback, project details, references | detail-index.md -> individual .md files | Loaded on-demand |
 | Instructions, process, guardrails | ~/.claude/rules/ | Loaded every session (no line limit) |
-| Domain knowledge, cross-project context | bundles/ | Loaded by routing weights |
+| Domain knowledge, cross-project context | bundles/ | Loaded by jit-knowledge/INDEX.md routing |
 | Project identity, architecture, key files | engrams/ | Loaded when working on that project |

--- a/templates/rules/routing-weights.md
+++ b/templates/rules/routing-weights.md
@@ -1,38 +1,23 @@
-# Routing Weights
+# Routing Weights -- DEPRECATED TEMPLATE
 
-Load context bundles based on task keywords. Each entry maps trigger phrases to one or more bundle names. When a user request matches a trigger, the listed bundles are loaded to provide domain-specific context.
+This template file is deprecated as of 2026-05-12 (Step 6 Layer B sweep).
 
-## Pattern
+The routing-weights.md pattern enacted routing locally. Routing now lives exclusively in:
 
-```
-- <trigger phrases>  -> [bundle-name]
-- <trigger phrases>  -> [bundle-a, bundle-b]
-```
+  https://github.com/dstolts/jit-knowledge/blob/main/INDEX.md
 
-## Example Routes
+## What to do instead
 
-```
-- Deploy / server / container / VM       -> [infrastructure]
-- API / endpoint / route / auth          -> [api-patterns]
-- Blog / post / publish / content        -> [content]
-- Sprint / story / prd / backlog         -> [sprint-workflow]
-- Test / spec / coverage / assertion     -> [testing]
-- Bug / error / debug / investigate      -> [infrastructure, integrations]
-```
+Do NOT create a routing-weights.md in your repo's `.claude/rules/`. Instead:
 
-## How It Works
+1. Add jit-knowledge as a submodule at `.jit-knowledge/` in your repo
+2. Set up `~/.claude/url-resolver.md` mapping the jit-knowledge GitHub URL to the local submodule path
+3. Reference INDEX.md for routing at session start (via CLAUDE.md or brainstem)
 
-1. AI scans the user's request for trigger keywords
-2. Matching bundles are loaded from the bundles directory
-3. Multiple bundles can load simultaneously for cross-domain tasks
-4. Unmatched requests use base context only (no extra bundles)
+For system-specific routing extensions (routes not in INDEX.md), add them ONLY to INDEX.md
+via a PR to jit-knowledge. Do not maintain a parallel local router.
 
-## Tips
+## Archive
 
-- Group related keywords on the same line (e.g., "deploy / server / container")
-- Use multi-bundle routes for tasks that span domains (e.g., "cross-repo sprint -> [sprint-workflow, infrastructure]")
-- Keep trigger phrases short -- 2-4 words per phrase is ideal
-- Order routes from most specific to most general
-- Add a "Full manifest" reference so AI can discover all available bundles
-
-Full manifest: .claude/context-manifest.md
+The original routing-weights.md template is preserved at:
+  `templates/.archive/rules-routing-weights.md`

--- a/templates/url-resolver.md
+++ b/templates/url-resolver.md
@@ -1,0 +1,50 @@
+# URL Resolver
+
+This file maps canonical GitHub URLs to local clone paths on this machine.
+It is machine-specific and MUST NOT be committed to git (add to .gitignore).
+
+The resolver lets consuming systems (Claude Code, Cursor, future agents) reference
+canonical artifacts by their stable GitHub URL while reading them at local filesystem
+speed. Install scripts create this file. Update the paths if you move clones.
+
+## Format
+
+```
+<GitHub URL>  ->  <absolute local path>
+```
+
+## Entries
+
+https://github.com/dstolts/jit-knowledge  ->  REPLACE_WITH_LOCAL_PATH
+
+<!-- Example entries:
+https://github.com/dstolts/jit-knowledge  ->  /home/user/Code/jit-knowledge
+https://github.com/dstolts/jit-knowledge  ->  C:/Users/user/Code/jit-knowledge
+-->
+
+## How it is used
+
+When a rule, engram, or command references a jit-knowledge artifact by GitHub URL,
+the consuming system reads this file first to resolve the URL to a local path:
+
+1. Read `~/.claude/url-resolver.md`
+2. Find the entry matching the URL prefix
+3. Replace the URL prefix with the local path
+4. Read the local file
+
+If no entry is found for a URL, the system falls back to fetching the file via
+the GitHub API (slower, requires network access).
+
+## Routing entry
+
+The canonical routing table lives at:
+  https://github.com/dstolts/jit-knowledge/blob/main/INDEX.md
+
+With a valid entry above, it resolves to:
+  <local path>/INDEX.md
+
+## Governance
+
+- Do not commit this file. It is machine-specific.
+- Update local paths after moving or re-cloning repositories.
+- Add entries for every jit-knowledge artifact your workflow reads.


### PR DESCRIPTION
## What

Step 6 Layer B follow-up: retire all references to the parallel-router pattern (context-manifest.md / routing-weights.md in MEMORY.md or rules/) across jitneuro docs and install scripts, and teach the replacement pattern throughout.

24 files changed. 1 new file created (templates/url-resolver.md).

## Why

Step 6 of the jit-knowledge canonicalization project retired two legacy surfaces (context-manifest.md and local routing-weights.md) and established jit-knowledge/INDEX.md as the single source of truth for all routing. The jitneuro docs and install scripts still taught the retired pattern, creating a propagation risk: new adopters following these docs would set up the old parallel-router instead of the canonical INDEX.md path.

This PR closes that gap. Every doc and template that instructed users to maintain routing weights locally or sync context-manifest.md has been updated to teach the INDEX.md + url-resolver.md workflow.

## Concepts retired

- context-manifest.md as a local bundle index and routing weight store
- routing-weights.md as a per-repo rules file for local routing
- MEMORY.md described as holding "routing weights"
- Orchestration reading context-manifest.md for routing decisions
- /learn writing routing entries to MEMORY.md or context-manifest.md
- /health checking for context-manifest.md presence
- /onboard step to update context-manifest.md
- /bundle scan comparing against context-manifest.md
- /session load reading context-manifest.md at restore time

## Concepts taught

- jit-knowledge/INDEX.md as the single source of truth for task-keyword -> bundle routing
- ~/.claude/url-resolver.md as the machine-specific GitHub URL -> local path resolver
- /learn flags missing routes for PR to jit-knowledge/INDEX.md (not local writes)
- /orchestrate reads INDEX.md (via url-resolver.md) for routing decisions
- /health checks url-resolver.md presence and INDEX.md entries
- /onboard suggests PR to INDEX.md for new bundle routes
- install.ps1 / install.sh scaffold url-resolver.md on fresh install; detect stale context-manifest.md with retirement notice

## Files updated

Docs (10):
- docs/concepts.md
- docs/setup-guide.md
- docs/memory-maintenance.md
- docs/cursor-and-cross-vendor.md
- docs/cursor-enablement-context.md
- docs/technical-overview.md
- docs/architecture.md
- docs/enterprise-isolation.md (cherry-picked from layer-b, carried forward)
- docs/master-session.md (cherry-picked from layer-b, carried forward)
- docs/ralph-integration.md (cherry-picked from layer-b, carried forward)

Templates (12):
- templates/CLAUDE-brainstem.md
- templates/commands/bundle.md
- templates/commands/enterprise.md
- templates/commands/health.md
- templates/commands/onboard.md
- templates/commands/orchestrate.md
- templates/commands/session.md
- templates/commands/verify.md
- templates/cursor/README.md
- templates/memory/README.md
- templates/context-manifest.md (tombstone pointer, cherry-picked from layer-b)
- templates/rules/routing-weights.md (tombstone pointer, cherry-picked from layer-b)

Install scripts (2):
- install.ps1
- install.sh

New file (1):
- templates/url-resolver.md

docs/routing-vs-semantic-memory.md -- retraction note added at top only; conceptual body left intact (documents design philosophy, not instructions).

## Risk

Zero production code changes. All changes are documentation, templates, and install scripts. No behavior change for existing installs (stale context-manifest.md is detected and flagged with a notice, not deleted).

## Test plan

- [x] install.ps1 syntax check: pwsh -Command "Get-Content install.ps1 | Out-Null" passed (method: PowerShell parser check)
- [x] install.sh syntax check: bash -n install.sh passed (method: bash -n dry-run)
- [x] Final grep for actionable context-manifest.md / routing-weights references: clean (method: grep sweep post-edit)
- [x] 24-file diff reviewed for conceptual accuracy before commit

## Ambiguous choices (review before merge)

1. docs/routing-vs-semantic-memory.md: The body discusses "routing weights" extensively as a design-philosophy concept (explicit keyword mapping vs semantic search). Rewriting it would destroy valuable conceptual content. Resolution: retraction note added at the top of the file redirecting readers to INDEX.md for current implementation; body left intact. If the whole doc should be retired, delete it post-merge.

2. Historical references in architecture.md release history table and technical-overview.md version notes use "routing weights" as a historical name for the feature. These describe past behavior accurately and were left as-is. No user confusion risk (they are in history/changelog context).

## Related

- jit-knowledge PR #61 (step6 layer-a: INDEX.md seeding)
- jit-knowledge PR #62 (step6 layer-b: template tombstones)
- jit-knowledge PR #63 (step6 layer-c: cleanup scripts)
- jit-knowledge PR #64 (step6 layer-d: governance rule)
- jitneuro PR #53 (feat: subscribe jitneuro to jit-knowledge canonical sync)