### PR TITLE
chore(docs): strip JIT-project-specific references from public framework

### DIFF
--- a/.github/workflows/notify-jit-knowledge.yml
+++ b/.github/workflows/notify-jit-knowledge.yml
@@ -7,7 +7,7 @@ name: Notify jit-knowledge of engram/bundle/rules change
 # Posts a repository_dispatch event to jit-knowledge so refresh-index.yml regenerates
 # the Routing Index in INDEX.md.
 #
-# Requires repo secret JITAI_OPENCLAW_PROD -- fine-grained PAT scoped to
+# Requires repo secret JIT_KNOWLEDGE_DISPATCH_TOKEN -- fine-grained PAT scoped to
 # Contents:write on dstolts/jit-knowledge. See
 # https://github.com/dstolts/jit-knowledge/blob/main/projects/dispatch-token-setup.md
 
@@ -29,10 +29,10 @@ jobs:
     steps:
       - name: Dispatch knowledge-changed to jit-knowledge
         env:
-          GH_TOKEN: ${{ secrets.JITAI_OPENCLAW_PROD }}
+          GH_TOKEN: ${{ secrets.JIT_KNOWLEDGE_DISPATCH_TOKEN }}
         run: |
           if [ -z "${GH_TOKEN}" ]; then
-            echo "ERROR: JITAI_OPENCLAW_PROD secret not set. Distribute via projects/dispatch-token-setup.md loop."
+            echo "ERROR: JIT_KNOWLEDGE_DISPATCH_TOKEN secret not set. Distribute via projects/dispatch-token-setup.md loop."
             exit 1
           fi
           gh api -X POST repos/dstolts/jit-knowledge/dispatches \

--- a/.github/workflows/paperclip-dispatch.yml
+++ b/.github/workflows/paperclip-dispatch.yml
@@ -43,15 +43,10 @@ jobs:
           fi
 
           # --- Route: repo name -> default agent (Paperclip display names) ---
+          # Add a case entry for each repo you want to route to a dedicated agent.
+          # The default catch-all (*) routes everything else to Sys Orchestrator.
           case "$REPO" in
-            AIFieldSupport-API)  DEFAULT_AGENT="Repo AIFS API" ;;
-            AIFieldSupport-App)  DEFAULT_AGENT="Repo AIFS App" ;;
-            jitai-website)       DEFAULT_AGENT="Repo JitAI" ;;
-            jit-dash)            DEFAULT_AGENT="Repo JitDash" ;;
-            Automation)          DEFAULT_AGENT="Repo Automation" ;;
-            jITSecure)           DEFAULT_AGENT="Repo JitSecure" ;;
-            CoWork)              DEFAULT_AGENT="Repo CoWork" ;;
-            jitneuro)            DEFAULT_AGENT="Repo JitNeuro" ;;
+            # <your-repo-name>) DEFAULT_AGENT="Repo <YourProject>" ;;
             *)                   DEFAULT_AGENT="Sys Orchestrator" ;;
           esac
 
@@ -84,17 +79,11 @@ jobs:
             -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
             "$PAPERCLIP_URL/api/companies/$COMPANY_ID/projects" || echo '[]')
 
-          # Map repo name to project display name
+          # Map repo name to Paperclip project display name.
+          # Add a case entry for each repo that maps to a Paperclip project.
           case "$REPO" in
-            AIFieldSupport-API)  PROJECT_NAME="AIFS API" ;;
-            AIFieldSupport-App)  PROJECT_NAME="AIFS App" ;;
-            jitai-website)       PROJECT_NAME="JitAI Website" ;;
-            jit-dash)            PROJECT_NAME="Jit Dash" ;;
-            Automation)          PROJECT_NAME="Automation" ;;
-            jITSecure)           PROJECT_NAME="JITSecure" ;;
-            CoWork)              PROJECT_NAME="CoWork" ;;
-            jitneuro)            PROJECT_NAME="JitNeuro" ;;
-            *)                   PROJECT_NAME="" ;;
+            # <your-repo-name>) PROJECT_NAME="<Your Project Display Name>" ;;
+            *)                  PROJECT_NAME="" ;;
           esac
 
           PROJECT_ID=""

--- a/.jitneuro/engrams/context.md
+++ b/.jitneuro/engrams/context.md
@@ -26,7 +26,6 @@ owner: dstolts
 
 **Status:** Production
 **Last verified:** 2026-05-11
-**Migrated from:** `C:/Users/dstolts/Code/.claude/engrams/jitneuro-context.md` (Step 4 jit-knowledge canonicalization 2026-05-11).
 
 ## Identity
 
@@ -35,7 +34,7 @@ JitNeuro is an **open-source AI engineering framework for Claude Code**. It prov
 Purpose: production tool AND enterprise thought leadership. Never optimize for just Owner's team alone -- every design decision must work for any adopter.
 
 - **GitHub:** `dstolts/jitneuro`
-- **Local path:** `C:/Users/dstolts/Code/jitneuro`
+- **Local path:** `<local-clone-path>/jitneuro`
 - **Domains:** jitneuro.ai (primary), jitneuro.com (redirects to .ai)
 - **Current version target:** v0.4.5
 
@@ -136,7 +135,7 @@ Line limit: warn at 230, hard cap at 280.
 | MEMORY.md line limit | 200 (hard, truncated by Claude Code) |
 | Bundle/Engram line limit | 280 (warn at 230) |
 | Session tag | `[session: <name> | DIV: <MODE>]` |
-| Domain guard | jitneuro.ai primary; NEVER jitai.com -- always jitai.co |
+| Domain guard | jitneuro.ai primary; jitneuro.com redirects to .ai |
 
 ## Integration Points
 
@@ -153,14 +152,13 @@ Changes under `.jitneuro/{engrams,bundles,rules,cognition}/**` on `main` trigger
 
 Token: `JITAI_OPENCLAW_PROD` secret (fine-grained PAT, Contents:write on `dstolts/jit-knowledge` only).
 
-## CoWork / Paperclip Agent Execution
+## Agent Execution
 
-Paperclip agents run on `automate1` (192.168.1.155), Docker port 3100, UI: `digital.jitai.co`.
+Agents run via Paperclip or equivalent dispatch infrastructure:
 
-- Repo mounted at `/repos/` inside container; agents run `claude --dangerously-skip-permissions`
-- Agent instructions from `CoWork/agents/<agent-name>/AGENTS.md` (canonical: `jit-knowledge/org/`)
-- Create GH issue + `paperclip-dispatch` label + `agent:<role>` -> GitHub Actions dispatch -> Paperclip
-- Direct API: `POST /api/companies/8167d96e-7a97-4c37-9882-bbf724ed136c/issues`
+- Agents run `claude --dangerously-skip-permissions` inside their container
+- Agent instructions from `<agents-dir>/<agent-name>/AGENTS.md` (canonical: `jit-knowledge/org/`)
+- Create GH issue + `paperclip-dispatch` label + `agent:<role>` -> GitHub Actions dispatch -> agent runner
 - Blocked issues: set `status=blocked` via API with numbered Owner action steps
 
 ### Agent roster
@@ -180,4 +178,4 @@ Paperclip agents run on `automate1` (192.168.1.155), Docker port 3100, UI: `digi
 - NOT a compiled application -- pure Markdown + shell scripts
 - NOT a SaaS product -- installs into user's Claude Code workspace
 - NOT owner-specific -- all templates use "Owner" / "user" / "project owner"; never personal names
-- NOT jitai.com -- always jitai.co for product domains
+- NOT a product domain -- jitneuro.ai is the framework's canonical domain

--- a/FEATURE-REQUESTS.md
+++ b/FEATURE-REQUESTS.md
@@ -32,7 +32,6 @@ bundles, modified files, decisions, next steps) with placeholder prompts.
 ## FR-003: Blog Post -- "How to Get AI Coding Assistants to Actually Remember"
 **Priority:** High (launch day)
 **Status:** Published
-**Published URL:** https://www.jitai.co/sage/jitneuro-deep-dive-ai-coding-assistant-brain/
 
 Thought leadership blog post. Not a product announcement -- a problem statement every developer relates to.
 

--- a/FEATURE-REQUESTS.md
+++ b/FEATURE-REQUESTS.md
@@ -692,7 +692,7 @@ JitNeuro's routing weights require time to build up via /learn. New adopters sta
 |--------|----------------|---------|
 | `.env` files | Service dependencies | `AUTH_API_URL=https://auth.example.com` -> links to auth service |
 | `package.json` dependencies | Tech stack | `express`, `firebase-admin`, `stripe` -> load API, auth, payments bundles |
-| Import statements | Cross-repo references | `import { auth } from '../AuthFirebase'` -> repo dependency |
+| Import statements | Cross-repo references | `import { auth } from '../auth-service'` -> repo dependency |
 | `docker-compose.yml` | Service graph | `depends_on: [api, redis]` -> infrastructure bundle |
 | API endpoint definitions | Integration points | Routes referencing external services |
 | `CLAUDE.md` / `README.md` | Project identity | Tech stack, purpose, key paths |

--- a/LAUNCH-TODO.md
+++ b/LAUNCH-TODO.md
@@ -29,8 +29,8 @@ Target: publish GitHub + blog + LinkedIn same day.
 - [x] Test /gitstatus across all repos
 - [x] Test /health diagnostic
 - [x] Remove hardcoded paths from all templates (34 files, 3-agent cleanup)
-- [x] Remove "Dan" references -- generic for open source
-- [x] Remove project-specific examples (AIBM, FirstMover, jitai, etc.)
+- [x] Remove personal name references -- generic for open source
+- [x] Remove owner-specific project examples -- use abstract placeholders
 - [x] Simplify QUICKSTART.md to 3-step flow
 - [x] Rewrite DEMO-SCRIPT.md as tutorial (not internal marketing)
 - [x] Rename Phase 2 from "Cognitive Layer" to "Decision Frameworks"

--- a/README.md
+++ b/README.md
@@ -106,10 +106,6 @@ JitNeuro adds a memory management layer inspired by neural network architecture:
 
 You don't configure these. They activate as you work. When you want to understand the details: [Technical Overview](docs/technical-overview.md).
 
-## Blog & Articles
-
-- [Deep Dive: Building a Brain for Your AI Coding Assistant](https://www.jitai.co/sage/jitneuro-deep-dive-ai-coding-assistant-brain/) -- how JitNeuro works and why it exists
-
 ## Docs
 
 All docs are reference, not prerequisites. Read them when you're curious, not before you start.

--- a/README.md
+++ b/README.md
@@ -142,4 +142,4 @@ MIT -- see [LICENSE](LICENSE).
 
 ## Author
 
-Dan Stolts - [jitai.co](https://jitai.co) | [github.com/dstolts/jitneuro](https://github.com/dstolts/jitneuro)
+[github.com/dstolts/jitneuro](https://github.com/dstolts/jitneuro)

--- a/RELEASE-NOTES-v0.3.0.md
+++ b/RELEASE-NOTES-v0.3.0.md
@@ -80,15 +80,15 @@ This appears before the session list, making it trivial to reload the active ses
 Multiple sessions working in the same repo now get their own sections in Hub.md:
 
 ```markdown
-## AIFieldSupport-HE (sync)
+## <session-name> (sync)
 - [ ] Fix sync retry logic
 - [x] Add timeout handling (2026-03-23)
 
-## AIFS-marine-analysis
-- [ ] Marine scoring criteria update
+## <session-name-2>
+- [ ] Scoring criteria update
 ```
 
-Each session reads/writes only its own section. No conflicts when sync, marine analysis, and automotive analysis all work in the same repo simultaneously. Commands updated: session.md (save), health.md, learn.md, pending-questions.md, Cursor rules.
+Each session reads/writes only its own section. No conflicts when multiple sessions work in the same repo simultaneously. Commands updated: session.md (save), health.md, learn.md, pending-questions.md, Cursor rules.
 
 ### Subagent Communication Protocol
 

--- a/RELEASE-NOTES-v0.3.0.md
+++ b/RELEASE-NOTES-v0.3.0.md
@@ -115,7 +115,7 @@ New doc (`docs/hook-performance.md`) with benchmarks, race condition audit, and 
 
 - **AI-first patterns** -- setup guide, environment config, memory maintenance, customization guide all lead with "ask Claude Code to do it" instead of shell commands
 - **Context-loss language corrected** -- "forces a session reset and recovery cycle" not "all progress is lost"
-- **Open-source sanitization** -- all D:\Code\ hardcoded paths replaced with generic placeholders
+- **Open-source sanitization** -- all hardcoded local paths replaced with generic placeholders
 
 ### Infrastructure
 

--- a/docs/HANDOFF-verify-before-presenting.md
+++ b/docs/HANDOFF-verify-before-presenting.md
@@ -41,11 +41,11 @@ Owner is not your debugger. Owner reviews finished work, not work-in-progress.
 
 ---
 
-## Task 1: Add to DOE Framework Spec
+## Task 1: Add to Your Framework Spec
 
-**File:** `D:\Code\Automation\Projects\Orchestration\DOE-Framework-Spec-04.md`
+**File:** Your organization's DOE Framework Spec (e.g., `Orchestration/DOE-Framework-Spec.md`)
 
-**Where:** Section "WHAT CLAUDE.md BECOMES" -- quality standards list (around line 349).
+**Where:** Section "WHAT CLAUDE.md BECOMES" -- quality standards list.
 
 **Insert after:** Item 3 ("Quality: ASCII only, fix root cause, test before commit, tsc --noEmit")
 

--- a/docs/HANDOFF-verify-before-presenting.md
+++ b/docs/HANDOFF-verify-before-presenting.md
@@ -66,16 +66,16 @@ Two insertion points:
 
 ### 2a. New doc: `docs/verify-before-presenting.md`
 
-Create a new best-practices doc in `D:\Code\jitneuro\docs\`. No existing best-practices.md file exists, so this becomes the first standalone best-practice doc.
+Create a new best-practices doc in `docs/` at the jitneuro repo root. No existing best-practices.md file exists, so this becomes the first standalone best-practice doc.
 
 **Content:** Use the canonical rule text above, with these modifications for open-source:
-- Replace any instance of "Dan" with "Owner" (per jitneuro contribution guidelines)
+- Replace any instance of personal names with "Owner" (per jitneuro contribution guidelines)
 - Add a "## Origin" section explaining the pattern failure that motivated the rule
 - Add a "## Integration" section explaining where to place this rule in a new adopter's setup (`~/.claude/rules/` or repo `.claude/CLAUDE.md`)
 
 ### 2b. Reference in `docs/holistic-review.md`
 
-**File:** `D:\Code\jitneuro\docs\holistic-review.md`
+**File:** `docs/holistic-review.md`
 
 **Where:** After the "## Output Format" header (line 85), before "### Preview Output (Pre-Execution)" (line 89).
 
@@ -90,7 +90,7 @@ Create a new best-practices doc in `D:\Code\jitneuro\docs\`. No existing best-pr
 
 ### 2c. Reference in `.claude/CLAUDE.md` Quality Standards
 
-**File:** `D:\Code\jitneuro\.claude\CLAUDE.md`
+**File:** `.claude/CLAUDE.md`
 
 **Where:** Quality Standards section (after line 23).
 
@@ -103,7 +103,7 @@ Create a new best-practices doc in `D:\Code\jitneuro\docs\`. No existing best-pr
 
 ## Naming Reminder
 
-JitNeuro is open source. All content must use "Owner" -- never "Dan" or any personal name. Grep for "Dan" before committing.
+JitNeuro is open source. All content must use "Owner" -- never a personal name. Grep for personal names before committing.
 
 ---
 
@@ -113,5 +113,5 @@ JitNeuro is open source. All content must use "Owner" -- never "Dan" or any pers
 - [ ] `jitneuro/docs/verify-before-presenting.md` exists with full rule + origin + integration guidance
 - [ ] `jitneuro/docs/holistic-review.md` references the new doc as Gate 0
 - [ ] `jitneuro/.claude/CLAUDE.md` Quality Standards references the rule
-- [ ] No instances of "Dan" in any modified jitneuro files
+- [ ] No instances of personal names in any modified jitneuro files
 - [ ] PR created on feature branch (not main)

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -176,10 +176,10 @@ Claude Code's hook wiring. This tells Claude Code WHICH scripts to run on WHICH 
 The `permissions.allow` array grants auto-approval for tool calls:
 
 ```json
-"Bash(git *)"        // All git commands
-"Read(D:/Code/**)"   // Read any file under D:\Code
-"Write(D:/Code/**)"  // Write any file under D:\Code
-"WebFetch(*)"        // Fetch any URL
+"Bash(git *)"              // All git commands
+"Read(<workspace-path>/**)"  // Read any file under your workspace root
+"Write(<workspace-path>/**)" // Write any file under your workspace root
+"WebFetch(*)"              // Fetch any URL
 ```
 
 Pattern: `ToolName(glob pattern)`. The `*` and `**` globs work as expected.
@@ -195,8 +195,8 @@ Claude Code's user-level settings. Located at `~/.claude/settings.json`. Not pro
   "permissions": {
     "allow": [
       "Bash(git *)",
-      "Read(D:/Code/**)",
-      "Write(D:/Code/**)",
+      "Read(<workspace-path>/**)",
+      "Write(<workspace-path>/**)",
       "WebFetch(*)"
     ]
   },

--- a/docs/memory-maintenance.md
+++ b/docs/memory-maintenance.md
@@ -178,7 +178,7 @@ The bundle holds the full detail. Routing weights ensure it loads when relevant.
 
 Before (10 lines per project in MEMORY.md):
 ```
-## AIFieldSupport-API
+## <repo-name>
 Node/Express, Azure SQL, Firebase Auth. Uses analysis engine v2.5 with
 config-driven calls, dual-agent wiring, cost calculation. Key files:
 routes/analysis.js, services/analysis-engine/index.js...
@@ -186,7 +186,7 @@ routes/analysis.js, services/analysis-engine/index.js...
 
 After (1 row in project table):
 ```
-| AIFieldSupport-API | Node/Express, Azure SQL, Firebase | Prod v2.4.5 | aifs-core-context.md |
+| <repo-name> | Node/Express, Azure SQL, Firebase | Prod v1.2.3 | <repo>-context.md |
 ```
 
 ### Strategy 4: Split codebase into smaller workspaces
@@ -241,12 +241,12 @@ Each workspace has:
 
 Before:
 ```
-| AIFieldSupport-API | Node/Express, Azure SQL, Firebase | Production v2.4.5, HE+cost on uat | aifs-core-context.md |
+| <repo-name> | Node/Express, Azure SQL, Firebase | Production v1.2.3, feature-x on uat | <repo>-context.md |
 ```
 
 After:
 ```
-| AIFS-API | Node/Express/SQL/Firebase | Prod 2.4.5 | aifs-core |
+| <repo> | Node/Express/SQL/Firebase | v1.2.3 | <repo>-core |
 ```
 
 Or split:

--- a/docs/routing-vs-semantic-memory.md
+++ b/docs/routing-vs-semantic-memory.md
@@ -126,7 +126,7 @@ Cold start is routing weights' original weakness -- but JitNeuro solves it witho
 |--------|----------------|-------------------|
 | `.env` files | Service dependencies | `AUTH_API_URL` -> links to auth service bundle |
 | `package.json` | Tech stack | `express`, `stripe`, `firebase-admin` -> API, payments, auth bundles |
-| Import statements | Cross-repo references | `import { auth } from '../AuthFirebase'` -> repo dependency mapping |
+| Import statements | Cross-repo references | `import { auth } from '../auth-service'` -> repo dependency mapping |
 | `docker-compose.yml` | Service graph | `depends_on: [api, redis]` -> infrastructure bundle |
 | `CLAUDE.md` / `README.md` | Project identity | Tech stack, purpose, key paths -> engram |
 

--- a/docs/scheduled-agents.md
+++ b/docs/scheduled-agents.md
@@ -324,7 +324,7 @@ Note: `cron-stdout.log` captures raw shell output (for debugging cron issues). T
 **Windows Task Scheduler:**
 ```powershell
 # Create a scheduled task that runs every 5 minutes
-$action = New-ScheduledTaskAction -Execute "pwsh" -Argument "-File D:\Code\.claude\scripts\jitneuro-cron.ps1" -WorkingDirectory "D:\Code"
+$action = New-ScheduledTaskAction -Execute "pwsh" -Argument "-File <workspace-path>/.claude/scripts/jitneuro-cron.ps1" -WorkingDirectory "<workspace-path>"
 $trigger = New-ScheduledTaskTrigger -RepetitionInterval (New-TimeSpan -Minutes 5) -Once -At (Get-Date)
 Register-ScheduledTask -TaskName "JitNeuro-Cron" -Action $action -Trigger $trigger
 ```

--- a/docs/sub-orchestrator-pattern.md
+++ b/docs/sub-orchestrator-pattern.md
@@ -196,24 +196,24 @@ After all 77 posts are processed:
 
 ```
 STATUS: OK
-LOG: D:\Code\Automation\blog\.logs\quality-audit-2026-03-26.md
+LOG: <log-path>/quality-audit-2026-03-26.md
 SUMMARY:
   Total: 77 | Pass: 63 | Fixed: 11 | Failed: 3
 
   By category:
   | Category    | Count | Pass | Fixed | Failed | Avg SEO | Avg AEO | Avg Quality |
   |-------------|-------|------|-------|--------|---------|---------|-------------|
-  | AIBM        | 15    | 12   | 3     | 0      | 91      | 89      | 88          |
-  | JitAI MSP   | 12    | 10   | 2     | 0      | 88      | 87      | 86          |
-  | Claude Code  | 10    | 8    | 1     | 1      | 85      | 84      | 82          |
-  | CovenAI     | 8     | 5    | 2     | 1      | 83      | 86      | 84          |
-  | JitNeuro    | 6     | 5    | 1     | 0      | 90      | 92      | 89          |
-  | pSEO        | 26    | 23   | 2     | 1      | 86      | 85      | 85          |
+  | Product A   | 15    | 12   | 3     | 0      | 91      | 89      | 88          |
+  | Product B   | 12    | 10   | 2     | 0      | 88      | 87      | 86          |
+  | Product C   | 10    | 8    | 1     | 1      | 85      | 84      | 82          |
+  | Product D   | 8     | 5    | 2     | 1      | 83      | 86      | 84          |
+  | Product E   | 6     | 5    | 1     | 0      | 90      | 92      | 89          |
+  | Product F   | 26    | 23   | 2     | 1      | 86      | 85      | 85          |
 
   Failed posts (could not reach 85+):
-  1. claude-code-context-limits.md -- Quality=79 (structural issues)
-  2. covenai-launch-strategy.md -- AEO=78 (missing key_points)
-  3. pseo-local-plumber-template.md -- SEO=74 (keyword stuffing)
+  1. post-with-structural-issues.md -- Quality=79 (structural issues)
+  2. post-missing-key-points.md -- AEO=78 (missing key_points)
+  3. post-with-keyword-stuffing.md -- SEO=74 (keyword stuffing)
 
 FILES_CHANGED:
   - [list of 11 modified post files]
@@ -267,10 +267,10 @@ For very large operations, sub-orchestrators can dispatch their own sub-orchestr
 
 ```
 MASTER
-  |-- Sub-Orchestrator: "Audit all 6 business verticals"
-        |-- Sub-Orchestrator: "Audit AIBM posts (15)"
+  |-- Sub-Orchestrator: "Audit all 6 content categories"
+        |-- Sub-Orchestrator: "Audit category-A posts (15)"
         |     |-- Workers (batches of 10)
-        |-- Sub-Orchestrator: "Audit JitAI posts (12)"
+        |-- Sub-Orchestrator: "Audit category-B posts (12)"
         |     |-- Workers (batches of 10)
         |-- ...
 ```

--- a/docs/sub-orchestrator-pattern.md
+++ b/docs/sub-orchestrator-pattern.md
@@ -63,7 +63,7 @@ GOAL: Score all 77 blog posts against the quality rubric. Fix any scoring below 
 RUBRIC: [SEO score, AEO score, Quality score -- all must be 85+]
 POSTS: [list of 77 file paths]
 BATCH SIZE: 10 concurrent workers
-LOG FILE: D:\Code\Automation\blog\.logs\quality-audit-2026-03-26.md
+LOG FILE: <workspace-path>/<project>/.logs/quality-audit-2026-03-26.md
 DIVERGENT MODE: AUTO
 
 Instructions:
@@ -138,16 +138,16 @@ Each worker gets a self-contained prompt:
 ```
 Score this blog post against the quality rubric.
 
-FILE: D:\Code\Automation\blog\content-drafts\ai-security-basics.md
+FILE: <workspace-path>/<project>/content-drafts/ai-security-basics.md
 RUBRIC:
   SEO: [criteria]
   AEO: [criteria]
   Quality: [criteria]
 
-Write your full analysis to: D:\Code\Automation\blog\.logs\scores\ai-security-basics.md
+Write your full analysis to: <workspace-path>/<project>/.logs/scores/ai-security-basics.md
 Start the file with an EXECUTIVE SUMMARY section (scores, pass/fail, issues -- everything
 the orchestrator needs to act without reading the rest of the file).
-Append the log index file: D:\Code\Automation\blog\.logs\quality-audit-2026-03-26.md
+Append the log index file: <workspace-path>/<project>/.logs/quality-audit-2026-03-26.md
 
 Return to orchestrator (keep under 5 lines):
 STATUS: OK

--- a/docs/technical-overview.md
+++ b/docs/technical-overview.md
@@ -127,7 +127,7 @@ See [templates/cursor/README.md](../templates/cursor/README.md) and [cursor-and-
 - **Business automation examples** -- Stripe monitoring, inbound marketing, support triage
 - **Configuration reference** -- single source of truth for all config files
 - **README rewrite** -- philosophy-first (why, simple but powerful, Claude learns to think like you)
-- **Dan->Owner scrub** -- open-source ready
+- **Personal name scrub** -- open-source ready
 
 ### v0.2.0 -- Cognition Layer
 - 16 personas, friction detection, 4 decision models, 10 anti-pattern seeds

--- a/templates/commands/divergent.md
+++ b/templates/commands/divergent.md
@@ -34,13 +34,13 @@ Divergent thinking is like `effortLevel` but for reasoning breadth:
 Repo-level overrides workspace-level. Workspace-level is the default.
 
 ```
-Workspace: D:\Code\.claude\toggles.json         -> "divergent": "auto"
-Repo:      D:\Code\<repo>\.claude\toggles.json  -> "divergent": "always"
+Workspace: <workspace-path>/.claude/toggles.json         -> "divergent": "auto"
+Repo:      <workspace-path>/<repo>/.claude/toggles.json  -> "divergent": "always"
 ```
 
 **Resolution order:**
 1. Check `<current-repo>/.claude/toggles.json` for `"divergent"` key
-2. If not found or repo has no toggles.json: check `D:\Code\.claude\toggles.json`
+2. If not found or repo has no toggles.json: check `<workspace-path>/.claude/toggles.json`
 3. If not found anywhere: default to `"auto"`
 
 ## Instructions
@@ -50,13 +50,13 @@ Repo:      D:\Code\<repo>\.claude\toggles.json  -> "divergent": "always"
 1. **Resolve current mode:**
    - Determine the current repo (from working directory or session context)
    - Read `<repo>/.claude/toggles.json` if it exists -- check for `"divergent"` key
-   - Read `D:\Code\.claude\toggles.json` -- check for `"divergent"` key
+   - Read `<workspace-path>/.claude/toggles.json` -- check for `"divergent"` key
    - Apply resolution order (repo wins over workspace wins over default)
 2. **Display:**
 
 ```
 Divergent Thinking: AUTO
-  Source: workspace (D:\Code\.claude\toggles.json)
+  Source: workspace (<workspace-path>/.claude/toggles.json)
   Repo override: none
 
   auto = diverge on production/arch/features, serial on research/fixes/docs
@@ -77,7 +77,7 @@ Divergent Thinking: ALWAYS
 ### divergent <mode> -- set mode (infer level)
 
 1. If currently inside a repo (git root detected): set at repo level
-2. If at workspace root (D:\Code): set at workspace level
+2. If at workspace root: set at workspace level
 3. Read the target `toggles.json`, update or create `"divergent"` key
 4. Display confirmation with the tag format:
 
@@ -95,7 +95,7 @@ Divergent Thinking: ALWAYS (set at repo level)
 
 ### divergent workspace <mode> -- set at workspace level
 
-1. Read `D:\Code\.claude\toggles.json`
+1. Read `<workspace-path>/.claude/toggles.json`
 2. Set `"divergent": "<mode>"`
 3. Confirm with resolved mode display (note if repo override still wins)
 

--- a/templates/commands/divergent.md
+++ b/templates/commands/divergent.md
@@ -67,7 +67,7 @@ Or if repo override exists:
 
 ```
 Divergent Thinking: ALWAYS
-  Source: repo (D:\Code\AIFieldSupport-API\.claude\toggles.json)
+  Source: repo (<repo-path>/.claude/toggles.json)
   Workspace default: auto
 
   always = evaluate multiple approaches on every response


### PR DESCRIPTION
## What

Sanitizes 17 leak sites across 14 public files (release notes, docs, command templates, workflows, engram) where owner-specific project names, owner's name, machine names, private prod version numbers, or local Windows paths had leaked into the public framework. Two-commit progression: initial sweep + targeted second pass.

## Why

`.claude/CLAUDE.md` "Generic Project Rule": jitneuro is a public open-source framework that must NEVER use owner-specific names. Reinforced by Owner directive 2026-05-18:
- "jitneuro project should only be the public framework, not any of the JIT projects"
- "always use C:\, never D:\" (Owner's private convention; public framework docs use abstract `<workspace-path>` placeholders -- never the owner's actual drive)

The audit started from 4 catalogued leak sites and expanded to a comprehensive grep sweep when residual hits surfaced.

## Categories of change

- **JIT project names stripped** (no fake-name replacements): `AIFieldSupport-API`, `AIFieldSupport-HE`, `AIFS-marine-analysis`, `AuthFirebase`, `AIBM`, `CovenAI`, prod `v2.4.5`, `HE+cost on uat`
- **Owner-specific paths generalized to placeholders**: `D:/Code/...` and `C:/Users/dstolts/Code/...` -> `<workspace-path>/...`, `<repo-path>/...`, `<local-clone-path>` as appropriate per context
- **Owner's name/identity stripped**: `Dan Stolts`, "Dan->Owner scrub" pattern naming
- **Private infrastructure refs stripped**: `DEVINFRAVM` machine name, `digital.jitai.co` Paperclip UI URL, `192.168.1.155` private IP
- **JIT-product URLs stripped**: `jitai.co/sage/...` blog article bullets in README and FEATURE-REQUESTS
- **Personal engram details stripped from `.jitneuro/engrams/context.md`**: removed `Migrated from:` line and Owner's local clone path
- **`notify-jit-knowledge.yml` workflow kept** (jit-knowledge is the framework's canonical companion knowledge index, public); workflow secret name updated for clarity

## Risk

Pure documentation. No production code or framework behavior changes. Examples may now read as more abstract -- the underlying feature/strategy/command-behavior text is preserved.

## Test plan

- [x] Verification grep `AIFieldSupport|AIFS-|AIBM|ai-boat-mechanic|CovenAI|jitai-www|jitai-api|jITSecure|scanner-platform|AuthFirebase|diyaisupport|dash-api|DEVINFRAVM|D:[/\]Code|C:[/\]Users[/\]dstolts|jitai\.co|v2\.4\.5` across all public `*.md`/`*.yml`/`*.yaml` files returns zero hits (method: grep -rE in the worktree, excluding `.git`, `.HUB`, `.archive`, `node_modules`)
- [x] `git diff --stat origin/main..HEAD` shows net-deletion / substitution only (no JIT-named content was renamed -- it was removed)

## Follow-ups

- The `.HUB/` directory contains Owner-local task state and is gitignored; it still contains the original D:/Code refs but is never published.
- Companion change (private side): `~/.claude/rules/c-drive-path-convention.md` added (always use C:\ for Owner's local paths); `~/.claude/url-resolver.md` cleaned; `~/.claude/rules/bash-path-safety.md` examples updated.