### PR TITLE
chore(paths): update absolute path references after workspace reorg

### DIFF
--- a/templates/url-resolver.example.md
+++ b/templates/url-resolver.example.md
@@ -19,8 +19,8 @@ This file maps GitHub repo URLs to local filesystem paths so that consumers read
 | Repo URL | Local Path |
 |---|---|
 | https://github.com/dstolts/jit-knowledge | C:/Users/dstolts/Code/jit-knowledge |
-| https://github.com/dstolts/jitai-openclaw | C:/Users/dstolts/Code/jitai-openclaw |
-| https://github.com/dstolts/dash-api | C:/Users/dstolts/Code/dash-api |
+| https://github.com/dstolts/jitai-openclaw | C:/Users/dstolts/Code/_internal/jitai-openclaw |
+| https://github.com/dstolts/dash-api | C:/Users/dstolts/Code/_dash/dash-api |
 | https://github.com/dstolts/dash | (TBD -- add when cloned locally) |
 | https://github.com/dstolts/jitneuro | D:/Code/jitneuro |
 | https://github.com/dstolts/jitai-www | D:/Code/jitai-www |


### PR DESCRIPTION
Mechanical sweep updating absolute filesystem path references after workspace top-level reorg into `_public` / `_dash` / `_private` / `_internal` / `_aeo` / `_futures` / `_jitai` org buckets.

This commit contains only path-rewrite changes (e.g., `C:/Users/dstolts/Code/Automation` -> `C:/Users/dstolts/Code/_internal/Automation`). Both forward-slash and backslash variants updated. No logic changes.

Part of Repo-Reorg session 2026-05-18..2026-05-19.