### PR TITLE
fix(install): register Claude Code hooks as bare paths, not shell-prefixed

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -298,7 +298,7 @@ $hooksConfig = @{
             @{
                 matcher = ""
                 hooks = @(
-                    @{ type = "command"; command = "$BashPathFwd `"$HooksPathFwd/pre-compact-save.sh`""; timeout = 10 }
+                    @{ type = "command"; command = "$HooksPathFwd/pre-compact-save.sh"; timeout = 10 }
                 )
             }
         )
@@ -306,19 +306,19 @@ $hooksConfig = @{
             @{
                 matcher = ""
                 hooks = @(
-                    @{ type = "command"; command = "$BashPathFwd `"$HooksPathFwd/session-start-write-id.sh`""; timeout = 10 }
+                    @{ type = "command"; command = "$HooksPathFwd/session-start-write-id.sh"; timeout = 10 }
                 )
             }
             @{
                 matcher = ""
                 hooks = @(
-                    @{ type = "command"; command = "$BashPathFwd `"$HooksPathFwd/session-start-post-clear.sh`""; timeout = 10 }
+                    @{ type = "command"; command = "$HooksPathFwd/session-start-post-clear.sh"; timeout = 10 }
                 )
             }
             @{
                 matcher = "compact"
                 hooks = @(
-                    @{ type = "command"; command = "$BashPathFwd `"$HooksPathFwd/session-start-recovery.sh`""; timeout = 10 }
+                    @{ type = "command"; command = "$HooksPathFwd/session-start-recovery.sh"; timeout = 10 }
                 )
             }
         )
@@ -326,13 +326,13 @@ $hooksConfig = @{
             @{
                 matcher = "Bash"
                 hooks = @(
-                    @{ type = "command"; command = "$BashPathFwd `"$HooksPathFwd/branch-protection.sh`""; timeout = 10 }
+                    @{ type = "command"; command = "$HooksPathFwd/branch-protection.sh"; timeout = 10 }
                 )
             }
             @{
                 matcher = "Agent"
                 hooks = @(
-                    @{ type = "command"; command = "$BashPathFwd `"$HooksPathFwd/pre-agent-register.sh`""; timeout = 5 }
+                    @{ type = "command"; command = "$HooksPathFwd/pre-agent-register.sh"; timeout = 5 }
                 )
             }
         )
@@ -340,13 +340,13 @@ $hooksConfig = @{
             @{
                 matcher = ""
                 hooks = @(
-                    @{ type = "command"; command = "$BashPathFwd `"$HooksPathFwd/heartbeat.sh`""; timeout = 5 }
+                    @{ type = "command"; command = "$HooksPathFwd/heartbeat.sh"; timeout = 5 }
                 )
             }
             @{
                 matcher = "Agent"
                 hooks = @(
-                    @{ type = "command"; command = "$BashPathFwd `"$HooksPathFwd/post-agent-complete.sh`""; timeout = 5 }
+                    @{ type = "command"; command = "$HooksPathFwd/post-agent-complete.sh"; timeout = 5 }
                 )
             }
         )
@@ -354,7 +354,7 @@ $hooksConfig = @{
             @{
                 matcher = ""
                 hooks = @(
-                    @{ type = "command"; command = "$BashPathFwd `"$HooksPathFwd/session-end-autosave.sh`""; timeout = 10 }
+                    @{ type = "command"; command = "$HooksPathFwd/session-end-autosave.sh"; timeout = 10 }
                 )
             }
         )

--- a/install.sh
+++ b/install.sh
@@ -268,21 +268,21 @@ build_hooks_json() {
   cat <<HOOKJSON
 {
   "hooks": {
-    "PreCompact": [{ "matcher": "", "hooks": [{ "type": "command", "command": "bash \"${HOOKS_PATH_FWD}/pre-compact-save.sh\"", "timeout": 10 }] }],
+    "PreCompact": [{ "matcher": "", "hooks": [{ "type": "command", "command": "${HOOKS_PATH_FWD}/pre-compact-save.sh", "timeout": 10 }] }],
     "SessionStart": [
-      { "matcher": "", "hooks": [{ "type": "command", "command": "bash \"${HOOKS_PATH_FWD}/session-start-write-id.sh\"", "timeout": 10 }] },
-      { "matcher": "", "hooks": [{ "type": "command", "command": "bash \"${HOOKS_PATH_FWD}/session-start-post-clear.sh\"", "timeout": 10 }] },
-      { "matcher": "compact", "hooks": [{ "type": "command", "command": "bash \"${HOOKS_PATH_FWD}/session-start-recovery.sh\"", "timeout": 10 }] }
+      { "matcher": "", "hooks": [{ "type": "command", "command": "${HOOKS_PATH_FWD}/session-start-write-id.sh", "timeout": 10 }] },
+      { "matcher": "", "hooks": [{ "type": "command", "command": "${HOOKS_PATH_FWD}/session-start-post-clear.sh", "timeout": 10 }] },
+      { "matcher": "compact", "hooks": [{ "type": "command", "command": "${HOOKS_PATH_FWD}/session-start-recovery.sh", "timeout": 10 }] }
     ],
     "PreToolUse": [
-      { "matcher": "Bash", "hooks": [{ "type": "command", "command": "bash \"${HOOKS_PATH_FWD}/branch-protection.sh\"", "timeout": 10 }] },
-      { "matcher": "Agent", "hooks": [{ "type": "command", "command": "bash \"${HOOKS_PATH_FWD}/pre-agent-register.sh\"", "timeout": 5 }] }
+      { "matcher": "Bash", "hooks": [{ "type": "command", "command": "${HOOKS_PATH_FWD}/branch-protection.sh", "timeout": 10 }] },
+      { "matcher": "Agent", "hooks": [{ "type": "command", "command": "${HOOKS_PATH_FWD}/pre-agent-register.sh", "timeout": 5 }] }
     ],
     "PostToolUse": [
-      { "matcher": "", "hooks": [{ "type": "command", "command": "bash \"${HOOKS_PATH_FWD}/heartbeat.sh\"", "timeout": 5 }] },
-      { "matcher": "Agent", "hooks": [{ "type": "command", "command": "bash \"${HOOKS_PATH_FWD}/post-agent-complete.sh\"", "timeout": 5 }] }
+      { "matcher": "", "hooks": [{ "type": "command", "command": "${HOOKS_PATH_FWD}/heartbeat.sh", "timeout": 5 }] },
+      { "matcher": "Agent", "hooks": [{ "type": "command", "command": "${HOOKS_PATH_FWD}/post-agent-complete.sh", "timeout": 5 }] }
     ],
-    "SessionEnd": [{ "matcher": "", "hooks": [{ "type": "command", "command": "bash \"${HOOKS_PATH_FWD}/session-end-autosave.sh\"", "timeout": 10 }] }]
+    "SessionEnd": [{ "matcher": "", "hooks": [{ "type": "command", "command": "${HOOKS_PATH_FWD}/session-end-autosave.sh", "timeout": 10 }] }]
   }
 }
 HOOKJSON


### PR DESCRIPTION
fix(install): register Claude Code hooks as bare paths, not shell-prefixed

## What
install.sh and install.ps1 write each hook `command` as a bare script path.
Previously install.sh emitted `bash "<path>"` and install.ps1 emitted
`"<bash-exe>" "<path>"`.

## Why
Claude Code runs each hook `command` through its own shell. A shell prefix
makes that shell try to execute bash as bash's own script argument, failing
every PreToolUse / PostToolUse / SessionStart / SessionEnd / PreCompact hook
with "bash.exe: bash.exe: cannot execute binary file". No hook runs.

## Risk
Low. Touches only the two installers' hook-command construction. Hook script
contents, hook events, matchers, and timeouts are unchanged. Re-running an
installer re-registers hooks with the corrected command.

## Test plan
- [x] install.sh syntax clean (method: bash -n)
- [x] install.ps1 parses (method: PowerShell Parser::ParseFile)
- [x] every generated command is a bare path, no bash/bash.exe prefix (method: grep)
