### PR TITLE
docs(hooks): correct hook-command examples to bare script paths

### DIFF
--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -142,7 +142,7 @@ Claude Code's hook wiring. This tells Claude Code WHICH scripts to run on WHICH 
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"/path/to/.claude/hooks/script-name.sh\"",
+            "command": "/path/to/.claude/hooks/script-name.sh",
             "timeout": 10
           }
         ]

--- a/docs/enterprise-security.md
+++ b/docs/enterprise-security.md
@@ -84,7 +84,7 @@ Developers can execute but not modify.
          "matcher": "Bash",
          "hooks": [{
            "type": "command",
-           "command": "bash \"//server/jitneuro-policy/hooks/branch-protection.sh\"",
+           "command": "//server/jitneuro-policy/hooks/branch-protection.sh",
            "timeout": 5
          }]
        }]

--- a/docs/hooks-guide.md
+++ b/docs/hooks-guide.md
@@ -117,7 +117,9 @@ See [heartbeat.md](heartbeat.md) for the full heartbeat reference -- what it is,
 
 ### settings.local.json hooks block
 
-Add the following to `.claude/settings.local.json` in your project or workspace root:
+Add the following to `.claude/settings.local.json` in your project or workspace root.
+
+Each `command` is a **bare path to the hook script** -- nothing else. Claude Code runs every hook `command` through its own shell, so do NOT prefix it with `bash`, `bash.exe`, or any shell binary. A prefix makes the shell try to run bash as bash's own script argument and the hook fails at runtime with `bash.exe: bash.exe: cannot execute binary file`.
 
 ```json
 {
@@ -128,7 +130,7 @@ Add the following to `.claude/settings.local.json` in your project or workspace 
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"/path/to/.claude/hooks/pre-compact-save.sh\"",
+            "command": "/path/to/.claude/hooks/pre-compact-save.sh",
             "timeout": 10
           }
         ]
@@ -140,7 +142,7 @@ Add the following to `.claude/settings.local.json` in your project or workspace 
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"/path/to/.claude/hooks/session-start-write-id.sh\"",
+            "command": "/path/to/.claude/hooks/session-start-write-id.sh",
             "timeout": 5
           }
         ]
@@ -150,7 +152,7 @@ Add the following to `.claude/settings.local.json` in your project or workspace 
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"/path/to/.claude/hooks/session-start-recovery.sh\"",
+            "command": "/path/to/.claude/hooks/session-start-recovery.sh",
             "timeout": 10
           }
         ]
@@ -162,7 +164,7 @@ Add the following to `.claude/settings.local.json` in your project or workspace 
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"/path/to/.claude/hooks/branch-protection.sh\"",
+            "command": "/path/to/.claude/hooks/branch-protection.sh",
             "timeout": 5
           }
         ]
@@ -174,7 +176,7 @@ Add the following to `.claude/settings.local.json` in your project or workspace 
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"/path/to/.claude/hooks/heartbeat.sh\"",
+            "command": "/path/to/.claude/hooks/heartbeat.sh",
             "timeout": 5
           }
         ]
@@ -186,7 +188,7 @@ Add the following to `.claude/settings.local.json` in your project or workspace 
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"/path/to/.claude/hooks/session-end-autosave.sh\"",
+            "command": "/path/to/.claude/hooks/session-end-autosave.sh",
             "timeout": 10
           }
         ]
@@ -276,7 +278,7 @@ exit 0
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"/path/to/.claude/hooks/my-hook.sh\"",
+            "command": "/path/to/.claude/hooks/my-hook.sh",
             "timeout": 10
           }
         ]


### PR DESCRIPTION
docs(hooks): correct hook-command examples to bare script paths

## What
Fixes the settings.local.json hook examples in docs/hooks-guide.md (7),
docs/configuration-reference.md (1), and docs/enterprise-security.md (1):
each `command` is now a bare script path, not `bash "<path>"`. Adds a note
in hooks-guide.md explaining the correct format and the failure mode.

## Why
The docs taught the shell-prefixed `command` form that fails at runtime with
"bash.exe: bash.exe: cannot execute binary file" (the installer bug fixed in
v0.4.1). Docs must teach the corrected format so anyone hand-editing
settings.local.json does not reintroduce the bug.

## Risk
None. Documentation only.

## Test plan
- [x] no `"command": "bash` examples remain in docs (method: grep)
