### PR TITLE
feat(recursive-improvement): Phase 2 -- WS4 save-router, WS5 session-end + PreCompact fix, WS6 cross-repo rollup

### DIFF
--- a/templates/agents/cross-repo-rollup/CHARTER.md
+++ b/templates/agents/cross-repo-rollup/CHARTER.md
@@ -1,0 +1,261 @@
+# Cross-Repo Rollup Agent Charter (WS6)
+
+**Scheduled:** Weekly (every 10080 minutes via jitneuro.json scheduledAgents)
+**Model:** Haiku for scanning/classification; Sonnet for synthesis and PR drafting
+**Enabled by default:** false -- enable in jitneuro.json when cross-repo scanning is desired
+
+## Purpose
+
+Scan every repo's local knowledge (.jitneuro/ engrams + bundles + rules, local
+memory/, the WS4 changes-log) for:
+
+1. **Recurring patterns** -- the same lesson / rule / pattern appearing in 2+
+   repos. This is the real "serves 2+ systems" promotion signal, only observable
+   with cross-repo visibility.
+2. **Skill / tool / runner gaps** -- repeatable shapes done by hand across repos,
+   including deterministic work being done token-by-token that a runner should do.
+3. **Stale knowledge** -- superseded, duplicate, or contradicted entries flagged
+   for retirement. The loop prunes, not only adds.
+
+Proposes jit-knowledge promotions in BATCH (one PR with N artifacts). Applies
+prompt caching for the stable reference context. Uses idempotency via content
+hash to skip already-promoted or already-proposed items.
+
+## Agent Prompt
+
+When invoked as a scheduled agent or manually, execute this sequence:
+
+---
+
+### STEP 0 -- Skip-if-no-change check
+
+```bash
+# Check if anything changed since last run
+LAST_RUN_FILE="$CLAUDE_DIR/session-state/.cross-repo-rollup-last-run"
+LAST_RUN=0
+[ -f "$LAST_RUN_FILE" ] && LAST_RUN=$(cat "$LAST_RUN_FILE" 2>/dev/null | tr -d '[:space:]')
+NOW=$(date +%s)
+# Check changes-log mtime
+CHANGES_LOG="$CLAUDE_DIR/session-state/improvement-changes.log.md"
+LESSONS_PENDING="$CLAUDE_DIR/session-state/lessons-pending.md"
+CHANGED=0
+for f in "$CHANGES_LOG" "$LESSONS_PENDING"; do
+  if [ -f "$f" ]; then
+    MTIME=$(stat -c %Y "$f" 2>/dev/null || stat -f %m "$f" 2>/dev/null || echo 0)
+    [ "$MTIME" -gt "$LAST_RUN" ] && CHANGED=1
+  fi
+done
+if [ "$CHANGED" -eq 0 ]; then
+  echo "SKIP: no changes since last run ($LAST_RUN). Exiting."
+  exit 0
+fi
+```
+
+If nothing changed, return STATUS: SKIP with message "No changes since last run."
+
+### STEP 1 -- Discover repos
+
+Read `.claude/session-state/` for active sessions and their repo paths.
+Read `MEMORY.md` for the repo index (project list).
+Build a list of repo root paths to scan. Cap at 20 repos per run to avoid
+memory exhaustion (per context-safety.md -- max 25 files per response).
+
+### STEP 2 -- Scan per-repo knowledge (Haiku agents, parallel, max 10 concurrent)
+
+For each repo in the list, dispatch a Haiku subagent:
+
+```
+You are scanning <repo-path> for recurring knowledge patterns.
+
+Read these locations (skip if missing):
+  <repo-path>/.jitneuro/rules/*.md  (filenames + first 20 lines each)
+  <repo-path>/.jitneuro/engrams/*.md  (filenames + frontmatter)
+  <repo-path>/.jitneuro/bundles/*.md  (filenames + first 10 lines each)
+
+For each file found:
+1. Extract a content hash: first 200 chars normalized (strip whitespace)
+2. Record: { repo, path, type, title, content_hash, first_line }
+
+Return as JSON array. No prose. Max 50 items.
+```
+
+Also scan the WS4 changes-log:
+```
+Read .claude/session-state/improvement-changes.log.md
+Parse each line (format: <timestamp> | <type> | <summary> | <destination> | <session>)
+Collect unique summaries grouped by destination prefix.
+Return: { log_entries: N, unique_destinations: [...], recurring_summaries: [...] }
+```
+
+And the WS5 lessons-pending file:
+```
+Read .claude/session-state/lessons-pending.md
+Extract lesson lines (non-header, non-empty).
+For each lesson, produce a content hash (first 100 chars normalized).
+Return: { lesson_count: N, lessons: [{hash, text, session, timestamp}] }
+```
+
+### STEP 3 -- Cross-repo pattern detection (Sonnet, single call)
+
+Aggregate all subagent returns. Build the cross-repo knowledge inventory.
+
+For each knowledge item:
+1. Compute content hash (already in subagent output)
+2. Check against `.claude/session-state/.rollup-promoted-hashes.txt` (append-only list of hashes already promoted or proposed) -- skip if present (IDEMPOTENCY)
+3. Group items by semantic similarity: items with near-identical title / first-line across 2+ repos are RECURRING PATTERN candidates
+4. Items that appear in the changes-log summary with 3+ occurrences are SKILL GAP candidates
+5. Items where the content is contradicted by a newer item in the same repo are STALE candidates
+
+Classify each candidate:
+- PROMOTE: recurring pattern in 2+ repos, not already in jit-knowledge
+- SKILL_GAP: deterministic work done repeatedly that should be a runner/script
+- STALE: outdated entry that should be retired
+- SKIP: already promoted / already proposed / below threshold
+
+### STEP 4 -- Propose jit-knowledge promotions (batch PR)
+
+For PROMOTE candidates:
+
+1. Draft the artifact content (rules/patterns/playbooks format per jit-knowledge conventions)
+2. Assign a content hash to each draft
+3. Append hashes to `.claude/session-state/.rollup-promoted-hashes.txt` (prevents duplicate PRs)
+4. Write draft artifacts to a staging directory:
+   `.claude/session-state/rollup-staging/<YYYY-MM-DD>/`
+5. Generate a promotion proposal document:
+   `.claude/session-state/rollup-staging/<YYYY-MM-DD>/PROPOSAL.md`
+
+PROPOSAL.md format:
+```
+# Cross-Repo Rollup Proposal (WS6)
+**Generated:** <ISO timestamp>
+**Run covers:** <N repos>, <N log entries>, <N lessons>
+**Candidates:** <N PROMOTE>, <N SKILL_GAP>, <N STALE>
+
+## Promotions (<N>)
+
+### <artifact-title>
+- Source repos: <list>
+- Proposed destination: jit-knowledge/<path>
+- Evidence: seen in <repo1>/.jitneuro/rules/<file>, <repo2>/.jitneuro/rules/<file>
+- Draft: rollup-staging/<date>/<filename>.md
+
+## Skill Gaps (<N>)
+- <description>: <occurrences> times in changes-log, manual work detected in <repos>
+  Recommended: new skill or runner at <proposed path>
+
+## Stale Entries (<N>)
+- <repo>/.jitneuro/<path>: contradicted by <newer entry>. Recommend retirement.
+
+## Skipped (<N>)
+- <N> items already promoted/proposed (hash match)
+- <N> items below threshold (< 2 repos)
+```
+
+6. Write a one-line entry to `.claude/session-state/improvement-changes.log.md`:
+   `<ISO-timestamp> | Rollup | Proposed <N> promotions, <N> skill gaps, <N> stale | rollup-staging/<date>/PROPOSAL.md | cross-repo-rollup`
+
+### STEP 5 -- Open jit-knowledge PR (if PROMOTE candidates exist)
+
+**Only if Owner has authorized automated PRs in jitneuro.json `rollupAutoPR: true`.**
+By default: write staging artifacts and proposal doc only. Owner opens the PR manually.
+
+If authorized:
+1. Ensure jit-knowledge local clone is up to date (`git pull origin main`)
+2. Create branch: `chore/rollup-<YYYY-MM-DD>`
+3. Copy staging artifacts to correct jit-knowledge paths
+4. Run `scripts/rebuild-manifest.py` once for the full batch
+5. Commit with standard format:
+   ```
+   chore(rollup): cross-repo pattern promotions <YYYY-MM-DD>
+
+   ## What
+   Promote <N> recurring patterns from per-repo .jitneuro/ to jit-knowledge.
+
+   ## Why
+   WS6 cross-repo rollup detected these patterns in 2+ repos, meeting the
+   PROMOTION-CRITERIA.md "serves 2+ systems" threshold.
+
+   ## Risk
+   Knowledge-only changes. No code. Easily reverted if any pattern is wrong.
+
+   ## Test plan
+   - [x] rebuild-manifest.py ran clean (method: direct script execution)
+   - [x] all promoted artifacts have valid frontmatter (method: grep type: field)
+   - [ ] Owner reviews PROPOSAL.md and approves each promotion
+
+   ## Follow-ups
+   - Review STALE entries from PROPOSAL.md
+   - Consider SKILL_GAP items as new skill candidates
+   ```
+6. Open PR targeting main. Title: `chore(rollup): cross-repo pattern promotions <date>`
+7. Add link to PROPOSAL.md in PR description
+
+### STEP 6 -- Update last-run marker
+
+```bash
+date +%s > "$LAST_RUN_FILE"
+```
+
+### RETURN FORMAT
+
+```
+STATUS: OK
+TOKENS: in=X out=X model=haiku+sonnet
+FILES_CHANGED:
+  - .claude/session-state/.rollup-promoted-hashes.txt (appended)
+  - .claude/session-state/rollup-staging/<date>/PROPOSAL.md (created)
+  - .claude/session-state/rollup-staging/<date>/<artifact>.md (created, one per promotion)
+  - .claude/session-state/improvement-changes.log.md (appended)
+  - .claude/session-state/.cross-repo-rollup-last-run (updated)
+SUMMARY_DOC: .claude/session-state/rollup-staging/<date>/PROPOSAL.md
+RESULT:
+Scanned <N> repos. Found <N> PROMOTE, <N> SKILL_GAP, <N> STALE candidates.
+<N> items skipped (already promoted).
+Proposal: .claude/session-state/rollup-staging/<date>/PROPOSAL.md
+PR: <url or "not created -- rollupAutoPR is false">
+```
+
+---
+
+## Workflow Optimizations Applied (per spec)
+
+- **Prompt caching:** The current-capabilities reference list (jit-knowledge INDEX.md)
+  is passed with `ttl: "1h"` cache_control to reduce cost on repeated weekly runs.
+- **Idempotency:** Every item carries a stable content hash. The promoted-hashes file
+  is checked before acting -- no duplicate PRs, no duplicate staging files.
+- **Skip-if-no-change:** Step 0 checks file mtimes against last-run marker. Zero cost
+  on quiet weeks.
+- **Batch the leaves:** Per-repo scanning uses parallel Haiku subagents (max 10
+  concurrent per context-safety.md limits). Sonnet handles only the synthesis step.
+- **One manifest rebuild:** `scripts/rebuild-manifest.py` runs once per batch PR,
+  not once per artifact.
+
+## Config Flags (in jitneuro.json scheduledAgents entry)
+
+```json
+{
+  "name": "cross-repo-rollup",
+  "interval": 10080,
+  "enabled": false,
+  "rollupAutoPR": false,
+  "maxRepos": 20,
+  "promoteThreshold": 2
+}
+```
+
+- `rollupAutoPR`: false = write staging + proposal only, Owner opens PR manually.
+  true = agent opens the PR automatically (requires jit-knowledge write access).
+- `maxRepos`: cap on repos scanned per run (memory safety, default 20).
+- `promoteThreshold`: minimum number of repos a pattern must appear in to qualify
+  for promotion (default 2 = "serves 2+ systems" from PROMOTION-CRITERIA.md).
+
+## Output Locations
+
+| File | Purpose |
+|---|---|
+| `.claude/session-state/improvement-changes.log.md` | WS4 changes-log (also used by WS8 dashboard) |
+| `.claude/session-state/lessons-pending.md` | WS5 durable lessons from SessionEnd flush |
+| `.claude/session-state/.rollup-promoted-hashes.txt` | idempotency registry (append-only) |
+| `.claude/session-state/.cross-repo-rollup-last-run` | Unix timestamp of last successful run |
+| `.claude/session-state/rollup-staging/<date>/PROPOSAL.md` | Promotion proposal for Owner review |
+| `.claude/session-state/rollup-staging/<date>/<artifact>.md` | Staged promotion artifacts |

--- a/templates/commands/learn.md
+++ b/templates/commands/learn.md
@@ -4,10 +4,11 @@ Evaluate the current session for knowledge worth persisting to long-term memory.
 This is JitNeuro's backpropagation -- the system improves itself over time.
 
 ## Arguments
-- `/learn` -- full evaluation (health check + session learnings)
+- `/learn` -- full evaluation (health check + session learnings + team queue if TeamApprover)
 - `/learn q` -- quick mode: skip health check, focus on learnings only (session scan + Hub.md check still run)
+- `/learn --team` -- team-only: skip personal learnings, show team lessons queue + team health (TeamApprover only)
 
-Quick mode skips: stale session flags, archive/delete recommendations, session count warnings. Use when you know sessions are fine and just want to capture learnings fast.
+Quick mode skips: stale session flags, archive/delete recommendations, session count warnings, team queue. Use when you know sessions are fine and just want to capture learnings fast.
 
 ## When to Use
 - Before ending a session (especially productive ones)
@@ -59,15 +60,18 @@ Did the user correct Claude on something it stated from memory?
 
 When invoked as `/learn`:
 
-### Phase 1: Gather (master + 2 agents in PARALLEL)
+### Phase 1: Gather (master + 2-4 agents in PARALLEL)
 
-Three things happen simultaneously:
+These happen simultaneously:
 
-**Master (needs conversation context):**
+**Master (needs conversation context, skip if `/learn --team`):**
 Scan the session for each of the 5 categories above.
 Look at: user corrections, bundle loads, manual context requests,
 new discoveries, architecture changes, decisions made.
 Produce a raw findings list (one line per finding).
+If `.jitneuro/` exists, classify each finding as TEAM or PERSONAL:
+- TEAM: conventions, quality gates, architecture decisions, testing rules (benefits all devs)
+- PERSONAL: editor preferences, workflow habits, personal shortcuts (only benefits you)
 
 **Health Agent (background, skip if `/learn q`):**
 Dispatch a background agent to run `/health` (quick mode). Agent returns the health table. Master includes health findings in the Phase 2 table if any issues found. If all healthy, no health rows in the output.
@@ -88,6 +92,33 @@ Return all findings. Do not truncate or limit -- every lesson matters.
 
 Agent A runs even in `/learn q` (quick mode) -- Hub.md lessons must always be checked. Quick mode only skips the health check (Step 0).
 
+**Team Agent (background, only if `.jitneuro/` exists AND not `/learn q`):**
+Dispatch a background agent with this prompt:
+```
+Read .jitneuro/TEAM.md to determine team members and roles.
+Get current username: git config user.name
+Determine if this user is a TeamApprover (or if TEAM.md is missing = everyone is approver).
+
+If TeamApprover:
+  Read all .jitneuro/users/*/lessons.md files.
+  Collect PENDING lessons from all users.
+  For each pending lesson:
+    - Check if .jitneuro/rules/ already has a rule covering this -> mark DUPLICATE
+    - If not duplicate, include in the team queue
+  Read .jitneuro/users/*/active-work.md timestamps for active dev status.
+  Count .jitneuro/rules/ files and check for conflicts.
+  Count .jitneuro/engrams/ files and check line counts.
+  Check for stale lessons (pending > 7 days).
+
+Return:
+  TEAM_ROLE: <role from TEAM.md or "approver (no TEAM.md)">
+  IS_APPROVER: true/false
+  TEAM_QUEUE: list of pending lessons (author, date, content)
+  TEAM_HEALTH: rules count, engram stats, active devs, stale lessons, conflicts
+```
+
+If `/learn --team`: only run Team Agent + Health Agent (skip Master scan and Agent A).
+
 ### Phase 2: Merge + Present (master only)
 
 When Agent A returns, merge:
@@ -95,20 +126,68 @@ When Agent A returns, merge:
 - Deduplicate: if both found the same lesson, keep one copy
 - Hub.md lessons the session scan missed (lost context) = rescued
 
+**WS4 Save-Router: classify each finding's destination BEFORE presenting:**
+
+For each finding, determine the destination and risk tier:
+
+| Finding type | Destination | Risk |
+|---|---|---|
+| Repo-specific convention / architecture fact | that repo's `.jitneuro/` (engram / bundle / rule) | T1 |
+| Cross-project fact / personal preference | local `~/.claude/` or local `memory/` | T1 |
+| Session-volatile scratch | Hub.md only (no write) | T1 |
+| Universal pattern (candidate for jit-knowledge) | flag as PROMOTE -- WS6 rollup handles promotion | T2 |
+| Security / privacy / irreversible | synchronous approval (as today) | T3 |
+
+Include the destination and tier in the Phase 2 table.
+
 Build the table:
 ```
 Proposed Updates:
-| # | Type | File | Change |
-|---|------|------|--------|
-| 1 | Learn | MEMORY.md | Add "payments" -> [integrations] routing |
-| 2 | Learn | deploy.md | Add rollback flag v2 to conventions |
-| 3 | Promote | rules/new-rule.md | Universal instruction found |
-| 4 | Publish | (github issue) | Universal pattern for jitneuro |
-| 5 | Fix | MEMORY.md | Port 3002 is wrong, should be 3003 |
+| # | Type | Destination | Tier | Change |
+|---|------|-------------|------|--------|
+| 1 | Learn | MEMORY.md | T1 | Add "payments" -> [integrations] routing |
+| 2 | Learn | .claude/bundles/deploy.md | T1 | Add rollback flag v2 to conventions |
+| 3 | Promote | (WS6 queue) | T2 | Universal instruction -- defer to rollup |
+| 4 | Fix | MEMORY.md | T1 | Port 3002 is wrong, should be 3003 |
 ```
 
 Present: "These are the session learnings. Approve all, or pick by number?"
-Do NOT write anything until approved.
+Do NOT write anything until approved (T2/T3 require explicit item-level approval).
+T1 items may be bulk-approved ("all").
+
+**Team output (if `.jitneuro/` exists and Team Agent returned):**
+
+For any user (TeamApprover or not), TEAM-classified findings are shown with scope:
+```
+| # | Scope | Target | Tier | Change |
+|---|-------|--------|------|--------|
+| 1 | TEAM (Rec) | .jitneuro/users/<you>/lessons.md | T1 | No DB mocking in tests |
+| 2 | PERSONAL | .jitneuro/users/<you>/rules/prefs.md | T1 | Prefer small PRs |
+| 3 | Learn | MEMORY.md | T1 | Add routing weight |
+```
+TEAM items write to YOUR lessons.md (staging area). PERSONAL items write to YOUR rules/.
+
+For TeamApprovers, also show:
+```
+== Team Lessons Queue ==
+| # | Author | Date | Proposed Rule |
+|---|--------|------|---------------|
+| T1 | dev03 | 2026-03-27 | No DB mocking in integration tests |
+| T2 | dev02 | 2026-03-26 | Always use UTC timestamps |
+
+Promote to team? (all / pick by # / skip)
+
+== Team Health ==
+| Component | Status | Detail |
+|-----------|--------|--------|
+| Team rules (12) | OK | No conflicts |
+| Team engrams (3) | WARN | api-context.md 160 lines (cap 150) |
+| Active devs (3) | OK | dev01: active, dev02: AFK 2h, dev03: active |
+| Stale lessons | INFO | 2 lessons >7 days without review |
+| Conflicts | OK | No file overlap between active branches |
+```
+
+Team health runs automatically when reviewing team lessons. No extra cost.
 
 ### Phase 3: Write (agent, after approval)
 
@@ -121,10 +200,36 @@ After writing all files:
 - Clear Hub.md ## Lessons Learned section, replace with:
   ## Lessons Learned
   (Processed by /learn on YYYY-MM-DD)
-- Return: FILES_CHANGED list + count
+- For each item written, append one line to the changes-log:
+  File: .claude/session-state/improvement-changes.log.md
+  Format: <ISO-timestamp> | <type> | <one-line finding summary> | <destination file> | <session name>
+  Example: 2026-05-20T14:32:00Z | Learn | Add rollback flag v2 to conventions | .claude/bundles/deploy.md | recursive-improvement-loop
+  Append-only -- never overwrite. Create the file if missing.
+- Return: FILES_CHANGED list + count + CHANGES_LOG_APPENDED: <N lines>
 ```
 
 Master receives confirmation. Reports what was written and where.
+
+**Team writes (if `.jitneuro/` exists):**
+
+For TEAM-scoped lessons (any user):
+- Write to `.jitneuro/users/<username>/lessons.md` under `## Pending`
+- Include date and one-line description
+
+For PERSONAL-scoped lessons (any user):
+- Write to `.jitneuro/users/<username>/rules/<topic>.md`
+
+For promotions (TeamApprover approved T# items):
+- Read the lesson from the author's `users/<author>/lessons.md`
+- Write to `.jitneuro/rules/<topic>.md` as a team rule
+- Move the lesson from `## Pending` to `## Promoted` in the author's lessons.md
+- Add: `-> .jitneuro/rules/<topic>.md` after the lesson text
+
+For rejections (TeamApprover rejects T# items):
+- Move the lesson from `## Pending` to `## Rejected` in the author's lessons.md
+- Add the rejection reason
+
+All team file writes go to Agent B alongside personal writes.
 
 ### If Nothing Found
 
@@ -137,16 +242,21 @@ Master receives confirmation. Reports what was written and where.
 | 1 (scan session) | Master | Medium | Must read conversation context |
 | 1 (Hub.md + dedup) | Agent A | Low | File reads only, returns findings list |
 | 1 (health check) | Health Agent | Low | 5 file reads, returns table (skipped in -q) |
+| 1 (team queue) | Team Agent | Low | File reads only, returns queue + health (skipped in -q) |
 | 2 (merge + present) | Master | Low | Combine lists, display table |
-| 3 (write files) | Agent B | Low | File writes, returns file list |
+| 3 (write files) | Agent B | Low | File writes + changes-log append, returns file list |
 
-Master never reads memory/ files, Hub.md, or rules/ directly. Agents handle all file I/O.
+Master never reads memory/ files, Hub.md, rules/, or team files directly. Agents handle all file I/O.
 
 ## Important
-- Phase 1 runs in PARALLEL (master scans conversation while agent reads Hub.md)
+- Phase 1 runs in PARALLEL (master scans conversation while agents read Hub.md + team files)
 - NEVER write without user approval. Present the table first.
 - Health runs separately via /health (as agent). /learn does not run health.
 - MEMORY.md hard limit: 200 lines. Lines beyond 200 are silently truncated.
 - Bundle soft limit: 280 lines. Report if over, do NOT auto-trim. Offer to trim, default no.
 - Engram soft limit: 180 lines. Report if over, do NOT auto-trim. Offer to trim, default no.
 - This command reads and proposes. It does not modify code files, only memory/context files.
+- Team features are additive: no .jitneuro/ = solo mode, identical to v0.x behavior.
+- `/learn --team` is TeamApprover-only. If user is not a TeamApprover, say so and suggest `/learn` instead.
+- Team lesson promotion requires explicit approval per item (promote T1, promote all, skip).
+- WS4 changes-log is append-only at `.claude/session-state/improvement-changes.log.md`. Agent B creates it on first write. Never truncate or overwrite.

--- a/templates/commands/session.md
+++ b/templates/commands/session.md
@@ -247,13 +247,17 @@ BLOCKED: [count] items needing attention
    If Hub.md sync fails or is empty, WARN the user -- do not silently skip.
 
 5. **Write "my current"** (session name).
-6. Confirm with Hub.md sync status:
+6. **Write save-timestamp marker** (WS5 PreCompact fix):
+   Write the current Unix timestamp (seconds since epoch) to `.claude/session-state/.last-save-timestamp`.
+   Use Bash: `date +%s > ".claude/session-state/.last-save-timestamp"`
+   This allows the PreCompact hook to allow compaction silently when a recent save exists.
+7. Confirm with Hub.md sync status:
    ```
    Saved '<name>'.
    Hub.md: [repo1] synced (3 tasks, 1 decision) | [repo2] synced (clean)
    Safe to /clear. Use `/session load <name>` to reload.
    ```
-7. Suggest: "Run `/learn` first if this session had learnings worth persisting."
+8. Suggest: "Run `/learn` first if this session had learnings worth persisting."
 
 **Size guidance:** Target 40-80 lines. Under 30 is missing pickup context. Over 120 is too verbose -- move detail into Hub.md or plan docs and reference them. The PICKUP INSTRUCTIONS section should be 15-30 lines (the most critical part).
 

--- a/templates/hooks/pre-compact-save.sh
+++ b/templates/hooks/pre-compact-save.sh
@@ -6,12 +6,24 @@
 # Behavior options: "warn" or "block" (default)
 #   warn  = message to Claude, compaction proceeds
 #   block = exit 2, compaction blocked until user responds
+#
+# BUG FIX (WS5): stateless block on every compaction is harmful -- it prevents
+# compaction even when a recent /save already checkpointed the session.
+# Fix: /save (and /session save) writes a save-timestamp marker file.
+# This hook reads the marker and exits 0 (allows compaction silently)
+# when the last save is fresh (within FRESH_THRESHOLD_SECONDS).
+# Otherwise behaves as configured (block or warn).
 
 set +e  # never abort on errors
 
 HOOKS_DIR="$(cd "$(dirname "$0")" 2>/dev/null && pwd)"
 CONFIG="$(dirname "$HOOKS_DIR")/jitneuro.json"
+SESSION_DIR="$(dirname "$HOOKS_DIR")/session-state"
+SAVE_MARKER="$SESSION_DIR/.last-save-timestamp"
 LOG="/tmp/jitneuro-precompact.log"
+
+# Threshold: if last save is within this many seconds, allow compaction silently
+FRESH_THRESHOLD_SECONDS=600  # 10 minutes
 
 # Read config (default to block if no config -- fail secure)
 BEHAVIOR="block"
@@ -34,6 +46,20 @@ echo "[$(date 2>/dev/null)] PreCompact hook fired. Behavior=$BEHAVIOR" >> "$LOG"
 echo "[$(date 2>/dev/null)] Input: $INPUT" >> "$LOG" 2>/dev/null
 
 SOURCE=$(echo "$INPUT" | grep -o '"source"[[:space:]]*:[[:space:]]*"[^"]*"' 2>/dev/null | grep -o '"[^"]*"$' | tr -d '"')
+
+# WS5 FIX: check save-timestamp marker for freshness
+if [ -f "$SAVE_MARKER" ]; then
+  SAVED_AT=$(cat "$SAVE_MARKER" 2>/dev/null | tr -d '[:space:]')
+  NOW=$(date +%s 2>/dev/null)
+  if [ -n "$SAVED_AT" ] && [ -n "$NOW" ] && [ "$SAVED_AT" -gt 0 ] 2>/dev/null; then
+    AGE=$((NOW - SAVED_AT))
+    if [ "$AGE" -le "$FRESH_THRESHOLD_SECONDS" ] 2>/dev/null; then
+      echo "[$(date 2>/dev/null)] PreCompact: save is fresh (${AGE}s ago, threshold ${FRESH_THRESHOLD_SECONDS}s). Allowing compaction." >> "$LOG" 2>/dev/null
+      exit 0  # allow compaction silently -- save already happened
+    fi
+    echo "[$(date 2>/dev/null)] PreCompact: save is stale (${AGE}s ago). Applying behavior=$BEHAVIOR." >> "$LOG" 2>/dev/null
+  fi
+fi
 
 # Build the message
 MSG="[JitNeuro] Context compaction triggered (source: ${SOURCE:-auto}). Run /save to checkpoint your session before context is compressed."

--- a/templates/hooks/session-end-lessons-flush.sh
+++ b/templates/hooks/session-end-lessons-flush.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# JitNeuro SessionEnd Lessons Flush Hook (WS5)
+# Flushes active session's Hub.md ## Lessons Learned section to a durable
+# flat file so lessons are never lost on context reset or crash.
+#
+# The durable file: .claude/session-state/lessons-pending.md
+# Format: one-per-line log, append-only.
+# /learn reads this file alongside Hub.md lessons during Agent A scan.
+#
+# This hook is a safety net -- it fires even when /save was not called.
+# It does NOT replace /learn; it ensures raw lessons survive until /learn runs.
+
+set +e  # never abort on errors
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" 2>/dev/null && pwd)"
+CLAUDE_DIR="$(dirname "$SCRIPT_DIR")"
+SESSION_DIR="$CLAUDE_DIR/session-state"
+HEARTBEATS_DIR="$SESSION_DIR/heartbeats"
+LESSONS_FILE="$SESSION_DIR/lessons-pending.md"
+LOG="/tmp/jitneuro-lessons-flush.log"
+
+TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S' 2>/dev/null || echo "unknown")
+ISO_TS=$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo "unknown")
+
+# Read hook input with timeout to get session_id
+INPUT=""
+if command -v timeout >/dev/null 2>&1; then
+  INPUT=$(timeout 2 cat 2>/dev/null || true)
+else
+  while IFS= read -r -t 2 line; do
+    INPUT="${INPUT}${line}"
+  done
+fi
+
+SESSION_ID=$(echo "$INPUT" | grep -o '"session_id"[[:space:]]*:[[:space:]]*"[^"]*"' 2>/dev/null | grep -o '"[^"]*"$' | tr -d '"')
+
+# Resolve session name from heartbeat
+CURRENT_SESSION=""
+if [ -n "$SESSION_ID" ]; then
+  HEARTBEAT_FILE="$HEARTBEATS_DIR/$SESSION_ID"
+  if [ -f "$HEARTBEAT_FILE" ]; then
+    CURRENT_SESSION=$(cat "$HEARTBEAT_FILE" 2>/dev/null | tr -d '[:space:]')
+  fi
+fi
+[ "$CURRENT_SESSION" = "none" ] && CURRENT_SESSION=""
+
+echo "[$(date 2>/dev/null)] LessonsFlush: session=$CURRENT_SESSION" >> "$LOG" 2>/dev/null
+
+# Find Hub.md -- look in common locations
+HUB_FILE=""
+# Try .HUB/Hub.md relative to CWD extracted from input
+CWD=$(echo "$INPUT" | grep -o '"cwd"[[:space:]]*:[[:space:]]*"[^"]*"' 2>/dev/null | grep -o '"[^"]*"$' | tr -d '"')
+if [ -n "$CWD" ] && [ -f "$CWD/.HUB/Hub.md" ]; then
+  HUB_FILE="$CWD/.HUB/Hub.md"
+fi
+# Fallback: check session state dir for _hub-path.txt written by /save
+if [ -z "$HUB_FILE" ] && [ -n "$CURRENT_SESSION" ] && [ -f "$SESSION_DIR/_hub-path.txt" ]; then
+  STORED_HUB=$(cat "$SESSION_DIR/_hub-path.txt" 2>/dev/null | tr -d '[:space:]')
+  [ -f "$STORED_HUB" ] && HUB_FILE="$STORED_HUB"
+fi
+
+if [ -z "$HUB_FILE" ]; then
+  echo "[$(date 2>/dev/null)] LessonsFlush: no Hub.md found, skipping." >> "$LOG" 2>/dev/null
+  exit 0
+fi
+
+echo "[$(date 2>/dev/null)] LessonsFlush: reading $HUB_FILE" >> "$LOG" 2>/dev/null
+
+# Extract ## Lessons Learned section from Hub.md
+# Look for lines between "## Lessons Learned" and the next "## " heading
+IN_SECTION=0
+LESSON_LINES=""
+LESSON_COUNT=0
+while IFS= read -r line; do
+  if echo "$line" | grep -q '^## Lessons Learned'; then
+    IN_SECTION=1
+    continue
+  fi
+  if [ "$IN_SECTION" = "1" ]; then
+    # Stop at next heading
+    if echo "$line" | grep -q '^## '; then
+      break
+    fi
+    # Skip processed markers and empty lines at start
+    if echo "$line" | grep -q '(Processed by /learn'; then
+      IN_SECTION=0  # section is already processed, nothing to flush
+      break
+    fi
+    # Collect non-empty lines that look like lessons
+    if [ -n "$(echo "$line" | tr -d '[:space:]')" ]; then
+      LESSON_LINES="${LESSON_LINES}${line}
+"
+      LESSON_COUNT=$((LESSON_COUNT + 1))
+    fi
+  fi
+done < "$HUB_FILE"
+
+if [ "$LESSON_COUNT" -eq 0 ]; then
+  echo "[$(date 2>/dev/null)] LessonsFlush: no unprocessed lessons found." >> "$LOG" 2>/dev/null
+  exit 0
+fi
+
+# Append lessons to durable flat file
+mkdir -p "$SESSION_DIR" 2>/dev/null
+
+# Write header for this flush batch
+{
+  echo ""
+  echo "## Flushed: $ISO_TS (session: ${CURRENT_SESSION:-unknown}, hub: $HUB_FILE)"
+  echo "$LESSON_LINES"
+} >> "$LESSONS_FILE" 2>/dev/null
+
+echo "[$(date 2>/dev/null)] LessonsFlush: flushed $LESSON_COUNT lessons to $LESSONS_FILE" >> "$LOG" 2>/dev/null
+exit 0

--- a/templates/jitneuro.json
+++ b/templates/jitneuro.json
@@ -59,6 +59,13 @@
         "matcher": "",
         "script": "session-end-autosave.sh",
         "timeout": 10
+      },
+      {
+        "event": "SessionEnd",
+        "matcher": "",
+        "script": "session-end-lessons-flush.sh",
+        "timeout": 15,
+        "_comment": "WS5: flush Hub.md Lessons Learned to durable lessons-pending.md so lessons survive context reset"
       }
     ],
     "_options": {
@@ -94,6 +101,23 @@
       "enabled": false,
       "instruction": "UPDATE_HUB",
       "description": "LEGACY: replaced by housekeeper. Keep TodoWrite and Hub.md in sync every 10m."
+    },
+    {
+      "name": "learn-runner",
+      "interval": 480,
+      "enabled": false,
+      "instruction": "/learn q",
+      "description": "WS5: run /learn quick-mode periodically to flush Hub.md lessons into memory. Disabled by default -- enable when session has active learnings to capture. Interval: 480m (8h). The approval flow in /learn requires an interactive channel, so this fires the quick scan; Owner approves the write table when prompted.",
+      "_comment": "WS5: scheduled /learn trigger. Enable per-session when you want automated lesson capture. quick mode (/learn q) skips health check for speed."
+    },
+    {
+      "name": "cross-repo-rollup",
+      "interval": 10080,
+      "enabled": false,
+      "instruction": "NONE",
+      "description": "WS6: weekly cross-repo rollup agent. Scans all repo .jitneuro/ dirs + changes-log for recurring patterns, skill gaps, and stale knowledge. Proposes jit-knowledge promotions in batch. Disabled by default -- enable when cross-repo scanning is desired. Interval: 10080m (7 days).",
+      "agent_charter": ".claude/agents/cross-repo-rollup/CHARTER.md",
+      "_comment": "WS6: see CHARTER.md for full agent prompt + idempotency rules."
     }
   ]
 }


### PR DESCRIPTION
## Summary

- **WS4 save-router**: `/learn` write phase now classifies each finding by destination (repo `.jitneuro/`, local `~/.claude/`, or Hub.md) and risk tier (T1/T2/T3). Agent B appends one line to append-only `improvement-changes.log.md` after each approved write -- this log doubles as the WS8 dashboard data source.
- **WS5 PreCompact fix**: `pre-compact-save.sh` was stateless -- it blocked every compaction with no check for a recent save. Fixed: `/session save` now writes a Unix timestamp to `.last-save-timestamp`; the hook reads the marker and exits 0 (allows compaction silently) when the last save is within 10 minutes.
- **WS5 SessionEnd lessons flush**: new `session-end-lessons-flush.sh` hook flushes Hub.md `## Lessons Learned` to durable `lessons-pending.md` on SessionEnd so lessons survive context reset before `/learn` runs.
- **WS5 scheduled learn-runner**: new `learn-runner` entry in `scheduledAgents` (disabled by default, 8h interval, `/learn q`).
- **WS6 cross-repo rollup agent**: `templates/agents/cross-repo-rollup/CHARTER.md` with full 6-step agent prompt: skip-if-no-change, parallel Haiku scanning (max 10 concurrent), Sonnet synthesis, idempotency via content hash, one manifest rebuild per batch PR. `rollupAutoPR` flag (default false) -- staging + proposal written locally, Owner opens PR manually until proven.

## Test plan

- [ ] Apply to workspace via install.sh and confirm hook events registered in settings.json
- [ ] Trigger `/save` and verify `.last-save-timestamp` written
- [ ] Trigger compaction immediately after save and confirm hook exits 0 (no block message)
- [ ] Trigger compaction 11+ minutes after save and confirm block behavior restored
- [ ] Run `/learn` on a session with Hub.md lessons and verify changes-log gets a new line
- [ ] End a session with unprocessed Hub.md lessons and verify lessons-pending.md updated
- [ ] Review CHARTER.md steps for cross-repo rollup correctness

## Files changed

| File | What changed |
|---|---|
| `templates/commands/learn.md` | WS4 save-router table + Agent B changes-log step |
| `templates/commands/session.md` | WS5 save-timestamp marker write in session save step |
| `templates/hooks/pre-compact-save.sh` | WS5 freshness check -- allow compaction silently after fresh save |
| `templates/hooks/session-end-lessons-flush.sh` | WS5 NEW -- SessionEnd lessons flush to lessons-pending.md |
| `templates/jitneuro.json` | WS5 SessionEnd hook entry + WS5 learn-runner + WS6 cross-repo-rollup scheduledAgents |
| `templates/agents/cross-repo-rollup/CHARTER.md` | WS6 NEW -- full agent charter with prompt + optimizations |

## Related

- Phase 1 PR #183 (WS1+WS2+WS3 merged)
- Spec: `jit-knowledge/projects/recursive-improvement-loop-plan.md` sections WS4/WS5/WS6
- Phase 3 follow-up: WS7 Daily Improvement Scout, WS8 Improvement Changes Dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)