### PR TITLE
fix(hooks): PreCompact hook must never block auto-compaction

### DIFF
--- a/templates/hooks/pre-compact-save.sh
+++ b/templates/hooks/pre-compact-save.sh
@@ -1,23 +1,35 @@
 #!/bin/bash
 # JitNeuro PreCompact Hook
-# Fires before context compaction -- prompts Claude to offer /save
+# Fires before context compaction.
 #
-# Config: .claude/jitneuro.json (hooks.preCompactBehavior)
-# Behavior options: "warn" or "block" (default)
-#   warn  = message to Claude, compaction proceeds
-#   block = exit 2, compaction blocked until user responds
+# A PreCompact hook MUST NOT block auto-compaction. When Claude Code
+# auto-triggers compaction the context window is full and compaction MUST
+# proceed -- returning exit 2 there wedges the session permanently. Therefore:
+#   - source=auto   -> always warn-only (exit 0); compaction proceeds
+#   - source=manual -> may pause (exit 2) only when preCompactBehavior=block
+#
+# Config: .claude/jitneuro.json (hooks.preCompactBehavior): "warn" | "block"
+#   Default is "warn" -- a non-destructive operation must never wedge a session
+#   by default. /save can run at any time, including after compaction.
+#
+# A fresh save (within FRESH_THRESHOLD_SECONDS) suppresses the message entirely.
 
 set +e  # never abort on errors
 
 HOOKS_DIR="$(cd "$(dirname "$0")" 2>/dev/null && pwd)"
 CONFIG="$(dirname "$HOOKS_DIR")/jitneuro.json"
+SESSION_DIR="$(dirname "$HOOKS_DIR")/session-state"
+SAVE_MARKER="$SESSION_DIR/.last-save-timestamp"
 LOG="/tmp/jitneuro-precompact.log"
 
-# Read config (default to block if no config -- fail secure)
-BEHAVIOR="block"
+# If the last save is within this many seconds, allow compaction silently.
+FRESH_THRESHOLD_SECONDS=600  # 10 minutes
+
+# Read config (default to warn -- never wedge a session by default)
+BEHAVIOR="warn"
 if [ -f "$CONFIG" ]; then
   BEHAVIOR=$(grep -o '"preCompactBehavior"[[:space:]]*:[[:space:]]*"[^"]*"' "$CONFIG" 2>/dev/null | head -1 | grep -o '"[^"]*"$' | tr -d '"')
-  [ -z "$BEHAVIOR" ] && BEHAVIOR="block"
+  [ -z "$BEHAVIOR" ] && BEHAVIOR="warn"
 fi
 
 # Read hook input from stdin with timeout
@@ -35,16 +47,30 @@ echo "[$(date 2>/dev/null)] Input: $INPUT" >> "$LOG" 2>/dev/null
 
 SOURCE=$(echo "$INPUT" | grep -o '"source"[[:space:]]*:[[:space:]]*"[^"]*"' 2>/dev/null | grep -o '"[^"]*"$' | tr -d '"')
 
-# Build the message
+# Fresh-save check: if a /save happened recently, allow compaction silently.
+if [ -f "$SAVE_MARKER" ]; then
+  SAVED_AT=$(cat "$SAVE_MARKER" 2>/dev/null | tr -d '[:space:]')
+  NOW=$(date +%s 2>/dev/null)
+  if [ -n "$SAVED_AT" ] && [ -n "$NOW" ] && [ "$SAVED_AT" -gt 0 ] 2>/dev/null; then
+    AGE=$((NOW - SAVED_AT))
+    if [ "$AGE" -le "$FRESH_THRESHOLD_SECONDS" ] 2>/dev/null; then
+      echo "[$(date 2>/dev/null)] PreCompact: save is fresh (${AGE}s ago). Allowing compaction silently." >> "$LOG" 2>/dev/null
+      exit 0
+    fi
+  fi
+fi
+
 MSG="[JitNeuro] Context compaction triggered (source: ${SOURCE:-auto}). Run /save to checkpoint your session before context is compressed."
 
-if [ "$BEHAVIOR" = "block" ]; then
+# CRITICAL: never block auto-compaction -- exit 2 there wedges the session.
+# Only an explicit manual /compact may be paused, and only when configured.
+if [ "$BEHAVIOR" = "block" ] && [ "$SOURCE" = "manual" ]; then
   echo "$MSG" >&2
-  echo "Compaction blocked by JitNeuro hook. Ask the user: save session with /save, then compact?" >&2
+  echo "Manual compaction paused by JitNeuro hook. Run /save, then re-run /compact." >&2
   exit 2
-else
-  # Warn mode: output goes to Claude as injected context
-  echo "$MSG"
-  echo "IMPORTANT: Before proceeding, ask the user if they want to run /save to checkpoint the current session state. If they say yes, run /save first, then allow compaction to proceed."
-  exit 0
 fi
+
+# Warn (default, and always for auto-compaction): compaction proceeds.
+echo "$MSG"
+echo "Compaction is proceeding. Run /save afterward if the session was not recently checkpointed."
+exit 0


### PR DESCRIPTION
## Hotfix -- production-breaking

The released PreCompact hook hard-blocks every compaction (`exit 2`, default `block`). When Claude Code auto-triggers compaction the context window is full and compaction MUST proceed -- blocking it wedges the session permanently. **Every JitNeuro user is currently unable to compact.**

## Fix
- `source=auto` compaction is now ALWAYS warn-only (exit 0) -- can never be blocked
- `source=manual` /compact may still pause (exit 2) only when `preCompactBehavior=block`
- Default behavior flipped `block` -> `warn` (a non-destructive op must not wedge a session by default)
- Fresh-save check: suppresses the message entirely when /save ran within 10 min

## Risk
Low -- hook script only, no app code. Strictly removes the only session-wedging path.

## Merge urgency
Hotfix targeting `main` directly (that is where the broken file is shipped and where installs pull from). Recommend immediate merge.

## Follow-ups
- Phase 2 PR #65 carries an older freshness-only version of this hook -- rebase #65 onto this fix.
- docs/hooks-guide.md still documents the old "block default" -- update.