### PR TITLE
feat(hooks): autonomous-continuation Stop hook + /afk command

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -331,6 +331,7 @@ build_hooks_json() {
   cat <<HOOKJSON
 {
   "hooks": {
+    "Stop": [{ "matcher": "", "hooks": [{ "type": "command", "command": "${HOOKS_PATH_FWD}/stop-continue-queue.sh", "timeout": 10 }] }],
     "PreCompact": [{ "matcher": "", "hooks": [{ "type": "command", "command": "${HOOKS_PATH_FWD}/pre-compact-save.sh", "timeout": 10 }] }],
     "SessionStart": [
       { "matcher": "", "hooks": [{ "type": "command", "command": "${HOOKS_PATH_FWD}/session-start-identity.sh", "timeout": 10 }] },

--- a/templates/commands/afk.md
+++ b/templates/commands/afk.md
@@ -1,0 +1,53 @@
+# /afk -- Arm/disarm autonomous continuation (work the queue unattended)
+
+Arms the autonomous-continuation Stop hook (`hooks/stop-continue-queue.sh`) so the
+session keeps working the `.HUB/Hub.md` ACTIVE TODO queue without stopping after each
+task. Use it when you step away and want the agent to keep executing the backlog.
+
+It works because the Stop hook fires in the harness when the model tries to yield, and
+re-injects "continue the queue" while executable tasks remain. A soft "keep going"
+instruction cannot do this; the model still stops. The hook makes it mechanical.
+
+## Usage
+
+```
+/afk            arm   -- keep working the queue until it is empty or fully blocked
+/afk on         arm
+/afk off        disarm -- return to normal (stop after each turn)
+/afk status     report whether autonomous mode is on
+```
+
+## What Claude does when invoked
+
+Resolve the flag path: `<project>/.claude/session-state/autonomous-mode.flag`
+(`<project>` = `$CLAUDE_PROJECT_DIR`, else the repo root).
+
+- **on / (no arg):** ensure `.HUB/Hub.md` exists and its `## ACTIVE TODO` reflects the
+  current task list (mirror TodoWrite first). Then write the flag, scoped to this
+  session: `echo "on:<session_id>" > <flag>`. Confirm: "Autonomous mode ARMED -- I will
+  work the Hub.md queue until it is empty or every remaining task is blocked. Disarm
+  with /afk off."
+- **off:** `rm -f <flag>`. Confirm: "Autonomous mode OFF -- back to normal stop-after-turn."
+- **status:** report whether the flag exists and its contents.
+
+When the owner signals AFK in plain language ("AFK", "stepping away", "be back later",
+"keep going while I'm gone"), arm autonomous mode the same way, and disarm it when they
+return.
+
+## Safety
+
+- **Safe by default:** with no flag, sessions stop normally. This command is the only
+  thing that arms it (besides the owner setting the flag directly).
+- **Runaway guard:** the hook stops itself after `JITNEURO_MAX_CONTINUE` (default 50)
+  consecutive turns with no queue progress, and never blocks when the queue is empty or
+  all remaining tasks are marked blocked / awaiting-owner.
+- **Long unattended runs:** Claude Code caps consecutive Stop-hook blocks (default 8).
+  For long queues, raise it: set `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP` (e.g., `999`) in your
+  environment or the `env` block of `settings.local.json`.
+- **Keep Hub.md current:** the hook reads `.HUB/Hub.md` `## ACTIVE TODO`. Mirror
+  TodoWrite to Hub.md as you work, or the hook cannot see progress.
+
+## Requires
+
+- `hooks/stop-continue-queue.sh` installed and registered on the `Stop` event
+  (both done by `install.sh`).

--- a/templates/hooks/README.md
+++ b/templates/hooks/README.md
@@ -53,6 +53,26 @@ This is NOT a full /save -- it only records that a session ended and where.
 If the user forgot to /save, this file confirms a session was active.
 Written to `.claude/session-state/_autosave.md` (overwritten each time).
 
+### 5. Autonomous Continuation (stop-continue-queue.sh)
+
+**Event:** `Stop` | **Matcher:** all | **Timeout:** 10s
+
+Makes autonomous execution MECHANICAL instead of advisory. A rule that says "keep
+working the queue" is soft -- the model reads it, agrees, and still yields control
+after each turn. This Stop hook fires when the model tries to stop and, while
+autonomous mode is ON and executable tasks remain in `.HUB/Hub.md` `## ACTIVE TODO`,
+blocks the stop (exit 2) and re-injects "continue the queue." Use it to hand the
+agent a backlog and walk away.
+
+**Safe by default:** does nothing unless armed. Arm with the `/afk` command (or
+`echo on > .claude/session-state/autonomous-mode.flag`); disarm with `/afk off`.
+
+**Runaway guard:** a progress-aware stall counter (resets when the open-task count
+drops) gives up after `JITNEURO_MAX_CONTINUE` (default 50) consecutive no-progress
+turns; it also allows the stop when the queue is empty or all remaining tasks are
+marked blocked / awaiting-owner. For long unattended runs, raise Claude Code's own
+consecutive-block cap via `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP` (e.g., `999`).
+
 ## Installation
 
 Add to `.claude/settings.local.json`:
@@ -122,6 +142,7 @@ Replace `/path/to/` with your actual workspace or project path.
 | session-start-recovery.sh | SessionStart | Re-inject context after compaction |
 | branch-protection.sh | PreToolUse (Bash) | Block RED zone git operations |
 | session-end-autosave.sh | SessionEnd | Safety net breadcrumb on exit |
+| stop-continue-queue.sh | Stop | Keep working the Hub.md queue unattended (armed via /afk) |
 | ../jitneuro.json | Config | Version, hook behavior, protected branches |
 
 ## Future Hooks (Planned)

--- a/templates/hooks/stop-continue-queue.sh
+++ b/templates/hooks/stop-continue-queue.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# JitNeuro Autonomous-Continuation Stop Hook (stop-continue-queue.sh)
+# Event: Stop -- fires when the agent finishes a turn and is about to yield control.
+#
+# PURPOSE: make autonomous execution MECHANICAL instead of advisory. While
+# "autonomous mode" is ON and executable tasks remain in the active Hub.md
+# queue, this hook BLOCKS the stop (exit 2) and re-injects a "continue the
+# queue" directive -- so the session keeps working a backlog unattended (AFK)
+# instead of stopping after each task. A soft rule ("keep going") cannot enforce
+# this; a hook fires in the harness and cannot be rationalized past by the model.
+#
+# SAFE BY DEFAULT: does NOTHING unless the autonomous-mode flag is set. Normal
+# interactive sessions are completely unaffected.
+#
+# Stop-hook exit contract (Claude Code):
+#   exit 0            -> allow the stop (normal yield)
+#   exit 2 + stderr   -> BLOCK the stop; stderr is fed back to the model as the next directive
+#   any other nonzero -> non-blocking error (also allows the stop)  => we FAIL-OPEN
+#
+# Enable :  echo on  > <project>/.claude/session-state/autonomous-mode.flag
+#           (optionally scope to one session: echo "on:<session_id>" > ...flag)
+#           -- or use the /afk slash command.
+# Disable:  rm <project>/.claude/session-state/autonomous-mode.flag   (or: echo off > it)
+#
+# Queue source: the first existing of  <cwd>/.HUB/Hub.md , <cwd>/.hub/hub.md ,
+# <project>/.HUB/Hub.md , <project>/.hub/hub.md  -- counts unchecked "- [ ]" lines,
+# excluding ones marked blocked/hold/awaiting/needs owner/red-zone/owner-gated.
+#
+# Runaway guard: a stall counter that RESETS on progress (remaining count drops).
+# After JITNEURO_MAX_CONTINUE (default 50) consecutive NO-PROGRESS turns it gives
+# up and allows the stop. Claude Code's own consecutive-block cap is a secondary
+# backstop; raise it via CLAUDE_CODE_STOP_HOOK_BLOCK_CAP for long unattended runs.
+
+set +e   # never abort; FAIL-OPEN -- a crash must allow the stop, never trap the session
+
+# ---- read hook payload (stdin JSON) ----
+INPUT=""
+if command -v timeout >/dev/null 2>&1; then
+  INPUT=$(timeout 2 cat 2>/dev/null || true)
+else
+  INPUT=$(cat 2>/dev/null || true)
+fi
+
+norm(){ printf '%s' "$1" | sed 's#\\\\#/#g; s#\\#/#g'; }
+
+CWD=$(printf '%s' "$INPUT" | sed -n 's/.*"cwd"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+[ -z "$CWD" ] && CWD="${CLAUDE_PROJECT_DIR:-$PWD}"
+CWD=$(norm "$CWD")
+
+SESSION_ID=$(printf '%s' "$INPUT" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+
+PROJECT_DIR=$(norm "${CLAUDE_PROJECT_DIR:-$CWD}")
+STATE_DIR="$PROJECT_DIR/.claude/session-state"
+FLAG="$STATE_DIR/autonomous-mode.flag"
+COUNTER="$STATE_DIR/.autonomous-stall-count"
+LOG="/tmp/jitneuro-autonomous.log"
+MAX_STALL="${JITNEURO_MAX_CONTINUE:-50}"
+
+log(){ echo "[$(date 2>/dev/null)] $*" >> "$LOG" 2>/dev/null; }
+
+# ---- safe-by-default: no active flag => allow stop ----
+[ -f "$FLAG" ] || { rm -f "$COUNTER" 2>/dev/null; exit 0; }
+FLAG_LINE=$(head -1 "$FLAG" 2>/dev/null | tr -d '\r' | tr -d '[:space:]')
+case "$FLAG_LINE" in
+  on|ON|on:*|ON:*) : ;;                              # active
+  *) rm -f "$COUNTER" 2>/dev/null; exit 0 ;;          # off / blank / unknown => allow stop
+esac
+
+# optional session scoping: "on:<session_id>" applies only to that session
+FLAG_SESSION="${FLAG_LINE#*:}"
+if [ "$FLAG_SESSION" != "$FLAG_LINE" ] && [ -n "$FLAG_SESSION" ] && [ -n "$SESSION_ID" ] && [ "$FLAG_SESSION" != "$SESSION_ID" ]; then
+  log "flag scoped to $FLAG_SESSION; current session $SESSION_ID -> allow stop"
+  exit 0
+fi
+
+# ---- locate the queue (Hub.md ACTIVE TODO) ----
+HUB=""
+for cand in "$CWD/.HUB/Hub.md" "$CWD/.hub/hub.md" "$PROJECT_DIR/.HUB/Hub.md" "$PROJECT_DIR/.hub/hub.md"; do
+  [ -f "$cand" ] && { HUB="$cand"; break; }
+done
+[ -n "$HUB" ] || { log "no Hub.md under $CWD / $PROJECT_DIR -> allow stop"; rm -f "$COUNTER" 2>/dev/null; exit 0; }
+
+# count executable unchecked tasks: "- [ ]" / "* [ ]" lines, excluding blocked/hold/awaiting
+REMAINING=$(grep -E '^[[:space:]]*[-*][[:space:]]*\[[[:space:]]\]' "$HUB" 2>/dev/null \
+            | grep -ivE '(blocked|on hold|[^a-z]hold|awaiting|needs owner|red.?zone|waiting on|owner-gated)' \
+            | grep -c . 2>/dev/null)
+REMAINING=$(printf '%s' "$REMAINING" | tr -cd '0-9'); REMAINING=${REMAINING:-0}
+
+# queue empty => work done => allow stop
+if [ "$REMAINING" -le 0 ]; then
+  log "queue empty in $HUB -> allow stop (done)"
+  rm -f "$COUNTER" 2>/dev/null
+  exit 0
+fi
+
+# ---- runaway guard: stall counter (resets on progress) ----
+PREV_COUNT=0; PREV_REM=999999
+if [ -f "$COUNTER" ]; then
+  PREV_COUNT=$(sed -n '1p' "$COUNTER" 2>/dev/null | tr -cd '0-9')
+  PREV_REM=$(sed -n '2p' "$COUNTER" 2>/dev/null | tr -cd '0-9')
+  PREV_COUNT=${PREV_COUNT:-0}; PREV_REM=${PREV_REM:-999999}
+fi
+if [ "$REMAINING" -lt "$PREV_REM" ]; then
+  COUNT=0                       # progress since last turn -> reset stall counter
+else
+  COUNT=$((PREV_COUNT + 1))     # no progress this turn
+fi
+
+if [ "$COUNT" -gt "$MAX_STALL" ]; then
+  log "stall cap hit ($COUNT > $MAX_STALL) on $HUB -> allow stop"
+  echo "AUTONOMOUS MODE: no queue progress for $MAX_STALL turns ($REMAINING task(s) still open in $HUB). Stopping to avoid a runaway loop. Review the stuck task, then re-arm with: echo on > $FLAG" >&2
+  rm -f "$COUNTER" 2>/dev/null
+  exit 0
+fi
+
+printf '%s\n%s\n' "$COUNT" "$REMAINING" > "$COUNTER" 2>/dev/null
+
+# ---- block the stop; inject the continue directive ----
+log "BLOCK: $REMAINING open in $HUB (stall $COUNT/$MAX_STALL) session=$SESSION_ID"
+echo "AUTONOMOUS MODE ON -- do NOT stop. $REMAINING executable task(s) remain in the queue ($HUB '## ACTIVE TODO'). Pick the next unblocked task, mark it in_progress, do the work end-to-end, update Hub.md (check it off, or mark it blocked/awaiting-owner with the reason), then continue to the next task. If EVERY remaining task is genuinely blocked on the owner or a RED-zone approval, mark them so in Hub.md and run: rm $FLAG  (to release autonomous mode). (continuation; stall $COUNT/$MAX_STALL)" >&2
+exit 2


### PR DESCRIPTION
## What
Adds a mechanical autonomy gate so a JitNeuro session can work a `.HUB/Hub.md` backlog **unattended** instead of yielding control after every turn.

- `templates/hooks/stop-continue-queue.sh` (new) -- a `Stop` hook. While autonomous mode is armed AND executable tasks remain in `## ACTIVE TODO`, it blocks the stop (exit 2) and re-injects "continue the queue."
- `templates/commands/afk.md` (new) -- `/afk` arms, `/afk off` disarms, `/afk status` reports.
- `install.sh` -- registers the `Stop` hook in `build_hooks_json()` so new installs wire it.
- `templates/hooks/README.md` -- documents the hook.

## Why
A rule that says "keep going until the queue is empty" is advisory -- the model reads it, agrees, and still stops, because ending the turn is a hard harness behavior. A Stop hook fires in the harness and cannot be rationalized past, so autonomy becomes mechanical.

## Safety
- **Safe by default:** no-op unless armed (`/afk` writes `.claude/session-state/autonomous-mode.flag`). Normal interactive sessions are unaffected.
- **Fail-open:** any hook error allows the stop (never traps a session).
- **Runaway guard:** progress-aware stall counter (resets when the open-task count drops) gives up after `JITNEURO_MAX_CONTINUE` (default 50) consecutive no-progress turns; allows stop when the queue is empty or all remaining tasks are marked blocked/awaiting-owner. For long unattended runs, raise `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`.
- **Session-scoped:** flag can be scoped `on:<session_id>` so it doesn't affect other sessions.

## Test plan
- [x] Hook logic: 6 scenarios pass (method: piped sample Stop-payload JSON to the script) -- allow when off / scoped-away / queue-empty / cap-hit; block when executable work remains; stall counter resets on progress and caps on genuine stall.
- [ ] Install wiring (method: run install.sh into a scratch target, confirm Stop registered in settings.local.json + hook copied executable).
- [ ] Live (method: arm via /afk in a session with a Hub.md queue, confirm it continues unattended and self-stops when empty).