### PR TITLE
fix(session): heartbeat-first on load (v0.5.1) so statusline + session tag resolve

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ JIT memory management framework for Claude Code -- persistent context across ses
 
 ## Status
 - **Phase:** Active Development
-- **Version:** v0.5.0
+- **Version:** v0.5.1
 - **Repo:** https://github.com/dstolts/jitneuro
 
 ## Tech Stack

--- a/RELEASE-NOTES-v0.5.0.md
+++ b/RELEASE-NOTES-v0.5.0.md
@@ -1,0 +1,80 @@
+# JitNeuro v0.5.0 Release Notes
+
+**Release Date:** June 12, 2026
+**Stability:** Stable
+**Breaking Changes:** None
+**Action Required:** YES -- re-run the installer to update the command/skill templates, and run `/knowledge` in any open session (see "How to update" below)
+
+---
+
+## Summary
+
+v0.5.0 fixes a session-load bug that caused the statusline (and the session tag) to show `none`/`?` even after a successful `/load`, and clarifies where the session tag belongs and what `DIV` actually confirms.
+
+The load procedure deferred its one mechanical step -- writing the heartbeat -- to the middle of the flow. When the owner appended a question to the load command (e.g. `/load my-session what's broken?`), the assistant treated the message as "answer the question," ran the answer, and never wrote the heartbeat. The session was effectively never loaded: the statusline had no name to read, and the session tag silently dropped.
+
+**Who should update:** Everyone. The fix lives in the `load`, `session`, and the `load`/`session` skill templates.
+
+---
+
+## The bug
+
+`/load <name>` delegates to `session load`, whose heartbeat write -- the single action the statusline reads -- sat at step 6, after several file reads. Two things then went wrong together:
+
+1. **Buried mechanical step.** Any interruption between resolving the name and step 6 left the heartbeat unwritten.
+2. **Appended-text trap.** When extra prose rode along with the command, the assistant prioritized the prose and skipped the load procedure entirely -- including the heartbeat write.
+
+Result: `heartbeats/<session-id>` was never created, the statusline's lookup fell through to `?`/none, and the session tag had no name to print, so it was dropped for the whole session. It looked like a statusline failure; it was a load failure.
+
+## The fix
+
+The heartbeat write is now the **first, unconditional action** of any load:
+
+- `templates/commands/load.md` -- new **step 0**: write the heartbeat before reading preferences or answering anything, with an explicit "appended-text trap" warning (appended text is an additional request, never a replacement for the load).
+- `templates/commands/session.md` -- `session load` writes the heartbeat the instant the name resolves (step 1), not at step 6. Step 6 re-affirms it; the write is idempotent.
+- `templates/skills/load/SKILL.md` and `templates/skills/session/SKILL.md` -- same reordering, so the skill surfaces match the command surfaces.
+
+## Session tag clarification
+
+The same release sharpens the session tag rule, because the bug exposed a conflation of two distinct displays:
+
+- The **statusline** mechanically carries the session **name**, read from the heartbeat by the statusline script. It is configured once and updates itself.
+- The **Stop tag** `[session: <name> | DIV: <MODE>]` is authored by the orchestrator at the **end of every response**. It is the per-turn confirmation that the orchestrator is **actively routing** -- consciously deciding, this turn, what mode applies. `DIV` is that routing confirmation, sourced from `toggles.json`; dropping the tag means routing was skipped.
+
+New, binding clarification in both `session.md` and the session skill: **an empty heartbeat means a broken load, not a missing tag.** If the heartbeat is empty when a session should be active, fix the load (write the heartbeat) -- do not silently print `none` or drop the tag.
+
+## How to recognize you are affected
+
+If, after running `/load <name>` (especially with a question appended), you have seen:
+
+- The statusline show `?` or no session name despite a "loaded" session
+- The `[session: ... | DIV: ...]` tag missing from responses
+- A session that behaves as though nothing was restored
+
+then you are affected.
+
+---
+
+## How to update
+
+1. Pull the latest JitNeuro (v0.5.0 or later).
+2. Re-run the installer for your platform, in the same mode you originally used:
+   - macOS / Linux / Git Bash: `bash install.sh`
+   - Windows PowerShell: `pwsh -File install.ps1`
+   The installer refreshes the `load`/`session` command and skill templates with the corrected procedure.
+3. **For sessions already open:** the command/skill files are read at invocation time, so the next `/load` or `/session` call already uses the corrected flow -- nothing to restart. The session-tag clarification, however, is auto-loaded knowledge; run `/knowledge` in each open session to re-read it (or just start a new session).
+
+---
+
+## What changed in this release
+
+- `templates/commands/load.md` -- step 0: write heartbeat first/unconditionally + appended-text trap.
+- `templates/commands/session.md` -- `session load` writes heartbeat on name-resolve; session tag rule clarified (Stop output vs statusline; DIV = routing confirmation; empty heartbeat = broken load).
+- `templates/skills/load/SKILL.md` -- heartbeat-first reordering + appended-text note.
+- `templates/skills/session/SKILL.md` -- heartbeat-first reordering; session tag rule clarified.
+- No changes to hooks, bundles, engrams, or any other JitNeuro feature.
+
+## Notes
+
+- Fix-only behavior change; no breaking changes and no new features.
+- The statusline script itself was always correct -- it had nothing to read because the load never wrote the heartbeat.

--- a/RELEASE-NOTES-v0.5.1.md
+++ b/RELEASE-NOTES-v0.5.1.md
@@ -1,4 +1,4 @@
-# JitNeuro v0.5.0 Release Notes
+# JitNeuro v0.5.1 Release Notes
 
 **Release Date:** June 12, 2026
 **Stability:** Stable
@@ -9,7 +9,7 @@
 
 ## Summary
 
-v0.5.0 fixes a session-load bug that caused the statusline (and the session tag) to show `none`/`?` even after a successful `/load`, and clarifies where the session tag belongs and what `DIV` actually confirms.
+v0.5.1 fixes a session-load bug that caused the statusline (and the session tag) to show `none`/`?` even after a successful `/load`, and clarifies where the session tag belongs and what `DIV` actually confirms.
 
 The load procedure deferred its one mechanical step -- writing the heartbeat -- to the middle of the flow. When the owner appended a question to the load command (e.g. `/load my-session what's broken?`), the assistant treated the message as "answer the question," ran the answer, and never wrote the heartbeat. The session was effectively never loaded: the statusline had no name to read, and the session tag silently dropped.
 
@@ -57,7 +57,7 @@ then you are affected.
 
 ## How to update
 
-1. Pull the latest JitNeuro (v0.5.0 or later).
+1. Pull the latest JitNeuro (v0.5.1 or later).
 2. Re-run the installer for your platform, in the same mode you originally used:
    - macOS / Linux / Git Bash: `bash install.sh`
    - Windows PowerShell: `pwsh -File install.ps1`
@@ -78,3 +78,4 @@ then you are affected.
 
 - Fix-only behavior change; no breaking changes and no new features.
 - The statusline script itself was always correct -- it had nothing to read because the load never wrote the heartbeat.
+- v0.5.0 was a prior version bump that shipped without a dedicated release-notes file; this fix ships as v0.5.1.

--- a/templates/commands/load.md
+++ b/templates/commands/load.md
@@ -6,6 +6,12 @@ Shortcut for `/session load`. Delegates to the session command.
 
 When invoked as `/load <name|#>`:
 
+0. **FIRST, UNCONDITIONALLY -- write the heartbeat.** Before reading preferences, before answering any question, before anything else: resolve the session name from the argument and write it to the heartbeat (Bash echo, never Write/Edit -- see `heartbeat-write-safety`):
+   ```bash
+   echo -n "<name>" > ".claude/session-state/heartbeats/<session-id>"
+   ```
+   This is the single action the statusline reads to resolve the active session. Skip it and the statusline shows `?`/none and the session is effectively not loaded.
+   **CRITICAL -- appended-text trap:** If the owner appends a question or extra prose to the command (e.g. `/load <name> <some question>`), that does NOT cancel the load. Write the heartbeat FIRST, run the full load flow, THEN address the appended text. Appended text is an additional request, never a replacement for the load procedure.
 1. Read `.claude/session-state/.preferences` for `shortcut_scope` setting
    - If `session` (default): execute `/session load <name|#>`
    - If `sessions`: execute `/session load <name|#>` (load always targets current session)

--- a/templates/commands/session.md
+++ b/templates/commands/session.md
@@ -42,6 +42,12 @@ Read by: default view, `pulse`, `dashboard`, and the session tag rule.
 If no active session: `[session: none | DIV: <MODE>]`.
 This is non-negotiable -- it prevents context confusion across terminals and provides constant visibility into the reasoning mode.
 
+**Tag location -- Stop output, NOT the statusline.** These are two distinct displays:
+- The **statusline** mechanically carries the session name (read from the heartbeat file by the statusline script). It is configured once and updates itself.
+- The **Stop tag** `[session: <name> | DIV: <MODE>]` is authored by the orchestrator at the **end of every response**. It is the per-turn confirmation that the orchestrator is actively routing -- consciously deciding, this turn, what mode applies. Dropping it means routing was skipped.
+
+**Empty heartbeat = broken load, not a missing tag.** If resolving "my current" yields an empty/absent heartbeat, the session was not loaded correctly (the heartbeat write was skipped). Fix the load (`/load` step 0 / `session load` step 1 write the heartbeat unconditionally) -- do NOT silently drop the tag or print `none` when a session was supposed to be active.
+
 ## Shortcut Preference
 
 Read `.claude/session-state/.preferences` for `shortcut_scope` setting.
@@ -268,6 +274,11 @@ BLOCKED: [count] items needing attention
    - If no name: **resolve "my current"**. If exists, load that.
    - If no name and no current: list sessions, ask user to pick
    - If number: resolve from last `/sessions` list output
+   - **IMMEDIATELY after resolving the name, write the heartbeat** (do NOT wait for step 6):
+     ```bash
+     echo -n "<name>" > ".claude/session-state/heartbeats/<session-id>"
+     ```
+     This is the single mechanical action the statusline depends on. Writing it first guarantees the load "took" even if a later step is interrupted or the owner appended a question to the command. (Step 6 re-affirms it; the write is idempotent.)
 
 2. **Read the session state file**
 

--- a/templates/skills/load/SKILL.md
+++ b/templates/skills/load/SKILL.md
@@ -27,9 +27,9 @@ Delegates entirely to `/session load [name|#]`. See `/session` SKILL.md for the 
 
 ## What load does
 
-1. Read the session checkpoint file from `.claude/session-state/<name>.md`
-2. Restore TodoWrite task list from the checkpoint
-3. Set active session name (write heartbeat via Bash echo -- see heartbeat-write-safety.md)
+1. **Set active session name FIRST -- write heartbeat via Bash echo** (see heartbeat-write-safety.md), the instant the name resolves. This is the action the statusline reads; doing it first guarantees the load "took." If the owner appended a question to the command, write the heartbeat first, finish the load, THEN answer -- appended text never cancels the load.
+2. Read the session checkpoint file from `.claude/session-state/<name>.md`
+3. Restore TodoWrite task list from the checkpoint
 4. Spawn scheduled agents if configured and not already running
 5. Display session summary and next actions
 

--- a/templates/skills/session/SKILL.md
+++ b/templates/skills/session/SKILL.md
@@ -36,10 +36,10 @@ Checkpoint current state:
 
 ### `/session load [name|#]`
 Restore from checkpoint:
-1. List available sessions if no name/# provided
-2. Read checkpoint file
-3. Restore TodoWrite task list
-4. Set heartbeat (Bash echo)
+1. Resolve the session name (list available sessions if no name/# provided)
+2. **Set heartbeat FIRST (Bash echo), the instant the name resolves** -- this is the action the statusline reads; do it before anything else so the load "took" even if a later step is interrupted. If the owner appended a question to the command, write the heartbeat first, finish the load, THEN answer.
+3. Read checkpoint file
+4. Restore TodoWrite task list
 5. Spawn scheduled agents if not running
 6. Display session summary + next actions
 
@@ -72,11 +72,12 @@ Show blockers and NEEDS OWNER items for current session.
 
 ## Session tag rule
 
-Every response ends with: `[session: <name> | DIV: <MODE>]`
+Every response ends with: `[session: <name> | DIV: <MODE>]` -- on the **Stop output**, NOT the statusline. The statusline mechanically shows the session name from the heartbeat; the Stop tag is the orchestrator's per-turn confirmation that it is actively routing.
 
 - Get `<name>` from your OWN heartbeat file ONLY (one read, one file)
 - Get `<MODE>` from toggles.json (AUTO / ALWAYS / NEVER)
 - Add `| STRATEGY` when strategy mode is active
+- **Empty heartbeat = broken load, not a missing tag.** If the heartbeat is empty when a session should be active, the load skipped the heartbeat write -- fix the load (`/load` step 0), do not silently drop the tag.
 
 ## Hub.md sync is MANDATORY on save
 


### PR DESCRIPTION
## What
Makes the heartbeat write the **first, unconditional** action of any `/load` (and `session load`), so the statusline and the Stop-output session tag resolve even when a question is appended to the load command. Clarifies the session-tag rule: the tag lives on the **Stop output**, not the statusline; `DIV` is the orchestrator's per-turn routing confirmation sourced from `toggles.json`. Ships as **v0.5.1** (v0.5.0 already promoted as a prior bump).

## Why
`/load <name> <question>` deferred its one mechanical step (heartbeat write) to mid-flow; the appended question caused the load to be skipped entirely, leaving `heartbeats/<id>` unwritten. The statusline fell through to `none`/`?` and the session tag dropped for the whole session. It looked like a statusline bug; it was a load bug.

## Risk
Low. Template + docs only. Two commits:
- `f1f6a9c` -- heartbeat-first reorder in `templates/commands/{load,session}.md` + `templates/skills/{load,session}/SKILL.md`.
- `b910544` -- version correction to v0.5.1 (rename notes, bump root CLAUDE.md).
No hooks/bundles/engrams touched. Consumers pick up the fix on next installer re-run.

## Test plan
- [x] Heartbeat now resolves on load (method: live `/load Knowledge` this session -- heartbeat reads `Knowledge [Master]`, statusline + Stop tag render)
- [x] Anonymize-repos gate clean on changed files (method: grep gate; only match = jitneuro's own canonical repo URL, allowed)
- [ ] Owner: run `/knowledge` in any other open session to load the tag-semantics change

## Related
- Origin: `/load Knowledge <question>` showed `none` session tag (RCA this session).
- Live install hotfixed on Owner machine (on-disk; reconcile rides installer re-run post-promotion).