### PR TITLE
fix(session): heartbeat-first on new-session/auto-create (v0.5.2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ JIT memory management framework for Claude Code -- persistent context across ses
 
 ## Status
 - **Phase:** Active Development
-- **Version:** v0.5.1
+- **Version:** v0.5.2
 - **Repo:** https://github.com/dstolts/jitneuro
 
 ## Tech Stack

--- a/RELEASE-NOTES-v0.5.2.md
+++ b/RELEASE-NOTES-v0.5.2.md
@@ -1,0 +1,68 @@
+# JitNeuro v0.5.2 Release Notes
+
+**Release Date:** June 13, 2026
+**Stability:** Stable
+**Breaking Changes:** None
+**Action Required:** Re-run the installer to update the command/skill/rule templates; run `/knowledge` in any open session (see "How to update").
+
+---
+
+## Summary
+
+v0.5.2 fixes the **new-session** form of the heartbeat bug that v0.5.1 fixed for **load**. Creating a session (via `/session new`, or auto-create on a fresh conversation) could skip writing the named heartbeat, so the statusline showed `none` and the session tag dropped -- exactly the symptom v0.5.1 addressed for `/load`, now closed on the creation path too.
+
+---
+
+## The bug
+
+The named heartbeat write -- the single action the statusline reads -- was deferred:
+
+- `/session new` wrote the heartbeat at **step 4**, after the save-prompt and after creating the session-state file. Any interruption before step 4, or an appended task riding along with the command, left the heartbeat unwritten.
+- **Auto-create** (a fresh conversation with no `/load`) instructed "auto-create a new session" but never made the heartbeat write a *first* action -- so the assistant could jump straight to the user's first request and never write it.
+
+Result: `heartbeats/<session-id>` was never created with the session name, the statusline fell through to `none`, and the session tag had no name to print. Same class as the v0.5.1 load bug, on the creation path.
+
+## The fix
+
+The named heartbeat write is now the **first action** on session establishment:
+
+- `templates/commands/session.md` -- `/session new` writes the heartbeat the instant the name is known (new **step 3**), before creating the state file, with an explicit appended-text-trap warning. The old step-4 write is removed (now redundant).
+- `templates/rules/session-guardrail.md` -- **auto-create** must write the named heartbeat as its FIRST action before answering anything, with the same trap warning.
+- `templates/skills/session/SKILL.md` -- `/session new` heartbeat write reordered to first, with the trap warning.
+
+## Why "first" matters
+
+The named heartbeat is the only thing the statusline reads, and only the assistant can supply the name (it is derived from the task). A SessionStart hook can create the file but writes `none` for a new session -- it cannot know the name. So the assistant writing the name first, unconditionally, is the fix. Deferring it is what let it get skipped.
+
+## How to recognize you are affected
+
+After starting a NEW session (especially with a task appended to `/session new`, or just starting to chat), if you have seen:
+
+- The statusline show `none` or no session name
+- The `[session: ... | DIV: ...]` tag missing from responses
+
+then you are affected.
+
+---
+
+## How to update
+
+1. Pull the latest JitNeuro (v0.5.2 or later).
+2. Re-run the installer in the same mode you originally used:
+   - macOS / Linux / Git Bash: `bash install.sh`
+   - Windows PowerShell: `pwsh -File install.ps1`
+3. **For sessions already open:** command/skill/rule files are read at invocation time, so the next `/session new` already uses the corrected flow. Run `/knowledge` in each open session to re-read the session-guardrail change (or start a new session).
+
+---
+
+## What changed in this release
+
+- `templates/commands/session.md` -- `/session new` heartbeat-first (step 3) + appended-text trap; redundant step-4 write removed.
+- `templates/rules/session-guardrail.md` -- auto-create writes the named heartbeat first, before any other work.
+- `templates/skills/session/SKILL.md` -- `/session new` heartbeat-first + trap warning.
+- No changes to hooks, bundles, engrams, or any other JitNeuro feature.
+
+## Notes
+
+- Fix-only behavior change; no breaking changes, no new features.
+- Sibling to v0.5.1 (load-side fix). Together they close the heartbeat-skip bug on both the load and create paths.

--- a/templates/commands/session.md
+++ b/templates/commands/session.md
@@ -104,7 +104,12 @@ BLOCKED: [count] items needing attention
    - If save+learn: run save flow, then suggest /learn
    - If save only: run save flow
    - If skip: proceed
-3. Create `.claude/session-state/<name>.md` with initial template:
+3. **Write the heartbeat FIRST -- the instant the new session name is known (from the `<name>` arg, or generated from the first request), before creating the state file or anything else:**
+   ```bash
+   echo -n "<name>" > ".claude/session-state/heartbeats/<session-id>"
+   ```
+   Create `heartbeats/` with `mkdir -p` if missing. Use Bash, never Write/Edit (the PostToolUse heartbeat hook races those). This is the one action the statusline reads; doing it first guarantees the session "took" even if a later step is interrupted. **Appended-text trap:** if a task or question rode along with `/session new`, write the heartbeat first, finish session creation, THEN address the task -- appended text never cancels the heartbeat write.
+4. Create `.claude/session-state/<name>.md` with initial template:
    ```markdown
    # Session: <name>
    **Checkpointed:** [current date/time]
@@ -123,8 +128,7 @@ BLOCKED: [count] items needing attention
    ## Next Steps
    - Awaiting direction
    ```
-4. **Write "my current"** (session name).
-5. Confirm: "Session '<name>' created."
+5. Confirm: "Session '<name>' created." (the heartbeat was already written in step 3.)
 6. **Spawn scheduled agents (mandatory):** Same process as `/session load` step 9. Read the project's config for `scheduledAgents`, spawn enabled agents, display confirmation or warning. New sessions need the interrupt mechanism from the start.
 
 ### session save <name>

--- a/templates/rules/session-guardrail.md
+++ b/templates/rules/session-guardrail.md
@@ -1,7 +1,13 @@
 # Session Guardrail
 
 At the start of every conversation, validate `.claude/session-state/heartbeats/<session-id>` resolves to an active session name.
-If the heartbeat file is empty, missing, or points to a non-existent/archived session, auto-create a new session immediately based on the first request before doing any other work.
+If the heartbeat file is empty, missing, or points to a non-existent/archived session, auto-create a new session immediately based on the first request. **Auto-create MUST write the heartbeat with the session name as its FIRST action, before doing any other work:**
+
+```bash
+echo -n "<name>" > ".claude/session-state/heartbeats/<session-id>"
+```
+
+Generate `<name>` from the first request (lowercase, hyphenated, task-descriptive). Use Bash echo only, never Write/Edit (the PostToolUse hook races those). **Appended-task trap:** if a task or question rode in with the first message, write the heartbeat FIRST, then address the task -- the request never cancels the heartbeat write. A skipped heartbeat is the new-session form of the load bug: the statusline shows `none` and the session tag drops.
 Claude NEVER operates under `[session: none]`. Every response requires an active session.
 
 ## Scheduled Agent Check (mandatory)

--- a/templates/skills/session/SKILL.md
+++ b/templates/skills/session/SKILL.md
@@ -19,7 +19,7 @@ Full session lifecycle management.
 ### `/session new [name]`
 Create a new session:
 1. Generate session name from task if not provided
-2. Write heartbeat: `echo -n "<name>" > heartbeats/$CLAUDE_SESSION_ID` (Bash, not Write tool)
+2. **Write heartbeat FIRST (before anything else):** `echo -n "<name>" > heartbeats/$CLAUDE_SESSION_ID` (Bash, not Write tool). If a task rode in with `/session new`, write the heartbeat first, finish creation, THEN address the task -- appended text never cancels the heartbeat write. A skipped heartbeat = statusline shows `none` and the session tag drops.
 3. Create `.claude/session-state/<name>.md` with header
 4. Create or update Hub.md entry
 5. Spawn scheduled agents from jitneuro.json (enabled: true)


### PR DESCRIPTION
## What
Sibling of the v0.5.1 load-side fix, on the **create** path. Makes the named heartbeat write the first, unconditional action on session creation.

- `templates/commands/session.md` -- `/session new` writes the heartbeat the instant the name is known (new step 3), before the state file; appended-text trap added; redundant step-4 write removed.
- `templates/rules/session-guardrail.md` -- **auto-create** writes the named heartbeat FIRST, before any other work.
- `templates/skills/session/SKILL.md` -- `/session new` heartbeat-first + trap warning.
- Version v0.5.1 -> **v0.5.2** + `RELEASE-NOTES-v0.5.2.md`.

## Why
Creating a session (via `/session new`, or auto-create on a fresh conversation) could skip writing the named heartbeat -- statusline showed `none`, session tag dropped. The new-session form of the v0.5.1 load bug. Only the assistant can supply the name (derived from the task), so writing it first, unconditionally, is the fix.

## Test plan
- [x] Anonymize gate clean (method: grep gate on changed files)
- [x] Mirrors v0.5.1 load fix structure (method: diff review of all 3 behavioral changes)
- [ ] Owner: start a new session post-install; confirm statusline shows the name, not `none`

## Risk
Template/docs only. No hooks/bundles/engrams touched. Consumers pick up the fix on next installer re-run.

## Related
Sibling to v0.5.1 (PR #75, load-side, already on uat). Together they close the heartbeat-skip bug on both load and create paths.