### PR TITLE
feat(commands): add /jitneuro-update -- turnkey framework update

### DIFF
--- a/templates/commands/jitneuro-update.md
+++ b/templates/commands/jitneuro-update.md
@@ -1,0 +1,57 @@
+# JitNeuro Update
+
+Update the installed JitNeuro framework to the latest version: pull the JitNeuro clone,
+re-run the installer (idempotent + version-aware), refresh the knowledge catalog, and verify.
+This is the turnkey `/jitneuro-update` -- read it and run it; it just happens.
+
+## When to Use
+- After a new JitNeuro release, to refresh commands / rules / hooks / dashboard
+- On a second machine, to bring it current with the latest framework + knowledge
+- When installed commands or hooks have drifted from the shipped templates
+- As the routine "bring me up to date" action
+
+## What It Does
+Re-running the installer IS the update path -- version-aware and idempotent. It backs up any
+framework file you edited, installs new/changed files, prunes ones the new version dropped
+(sha-guarded), and preserves your own files + your configured knowledgeRoot. Full contract:
+`skills/update/SKILL.md`.
+
+## Instructions
+
+When invoked as `/jitneuro-update`:
+
+### Step 1: Resolve the JitNeuro clone
+- Resolve the clone path: `JITNEURO_HOME` env -> `jitneuro.json` location -> the directory the
+  framework was installed from. If it cannot be resolved, ask the user for the clone path.
+
+### Step 2: Pull latest
+- `cd <jitneuro-clone>`
+- `git checkout main` (or the release tag the user pins)
+- `git pull --ff-only`
+- Note the previous version -> new version from `jitneuro.json`.
+
+### Step 3: Re-run the installer in the SAME scope
+- Detect the existing install scope (project / workspace / user). If unsure, run `/verify` first --
+  it reports the install path.
+- Windows PowerShell: `powershell -ExecutionPolicy Bypass -File scripts\install.ps1 -Mode <scope>`
+- macOS / Linux / Git-Bash: `bash scripts/install.sh <scope>`
+
+### Step 4: Refresh the knowledge catalog (if configured)
+- If a shared knowledge catalog (knowledgeRoot) clone is configured, pull it too so the catalog is
+  current: `cd <knowledgeRoot>` then `git pull --ff-only`.
+
+### Step 5: Restart + verify
+- Tell the user to restart the tool (slash commands + hooks load at session start).
+- After restart, run `/verify` to confirm components + hook events are healthy.
+
+### Step 6: Report
+- Report: version old -> new, what changed (commands / rules / hooks updated, files pruned),
+  knowledgeRoot, and any framework files that were backed up because the user had edited them.
+
+## Important
+- Idempotent + safe to re-run; never requires admin; no Python / Node dependency.
+- The installer NEVER overwrites the user's own files or a populated horizon / bundles / engrams dir.
+- A `(DISABLED)` first-line marker on a rule is respected (skipped, not restored).
+- Restart is mandatory -- an in-flight session will not see new commands / hooks until reopened.
+- This is the framework update only. To populate a repo's `.knowledge/` after updating, use the
+  repo-knowledge-adoption playbook.

--- a/templates/commands/jitneuro-update.md
+++ b/templates/commands/jitneuro-update.md
@@ -13,7 +13,8 @@ This is the turnkey `/jitneuro-update` -- read it and run it; it just happens.
 ## What It Does
 Re-running the installer IS the update path -- version-aware and idempotent. It backs up any
 framework file you edited, installs new/changed files, prunes ones the new version dropped
-(sha-guarded), and preserves your own files + your configured knowledgeRoot. Full contract:
+(sha-guarded), and preserves your own files + your configured knowledgeRoot (including your
+accumulated cognition/anti-patterns.md and jitneuro.json settings). Full contract:
 `skills/update/SKILL.md`.
 
 ## Instructions
@@ -31,10 +32,11 @@ When invoked as `/jitneuro-update`:
 - Note the previous version -> new version from `jitneuro.json`.
 
 ### Step 3: Re-run the installer in the SAME scope
+- The installer (`install.ps1` / `install.sh`) lives at the JitNeuro clone ROOT -- run it from there.
 - Detect the existing install scope (project / workspace / user). If unsure, run `/verify` first --
   it reports the install path.
-- Windows PowerShell: `powershell -ExecutionPolicy Bypass -File scripts\install.ps1 -Mode <scope>`
-- macOS / Linux / Git-Bash: `bash scripts/install.sh <scope>`
+- Windows PowerShell (from the clone root): `powershell -ExecutionPolicy Bypass -File install.ps1 -Mode <scope>`
+- macOS / Linux / Git-Bash (from the clone root): `bash install.sh <scope>`
 
 ### Step 4: Refresh the knowledge catalog (if configured)
 - If a shared knowledge catalog (knowledgeRoot) clone is configured, pull it too so the catalog is
@@ -50,7 +52,8 @@ When invoked as `/jitneuro-update`:
 
 ## Important
 - Idempotent + safe to re-run; never requires admin; no Python / Node dependency.
-- The installer NEVER overwrites the user's own files or a populated horizon / bundles / engrams dir.
+- The installer NEVER overwrites the user's own files or a populated horizon / bundles / engrams dir,
+  and never overwrites accumulated `cognition/anti-patterns.md` or your `jitneuro.json` settings.
 - A `(DISABLED)` first-line marker on a rule is respected (skipped, not restored).
 - Restart is mandatory -- an in-flight session will not see new commands / hooks until reopened.
 - This is the framework update only. To populate a repo's `.knowledge/` after updating, use the


### PR DESCRIPTION
## What
Adds the `/jitneuro-update` slash command (`templates/commands/jitneuro-update.md`) -- the turnkey framework update: resolve the JitNeuro clone, `git pull --ff-only`, re-run the version-aware idempotent installer in the same scope, refresh the knowledge catalog if configured, restart + `/verify`, and report what changed.

## Why
There was no first-class "update me to latest" command -- the update procedure lived only in `skills/update/SKILL.md`. This command is the read-and-execute entry point so a user (or a session on a second machine) can run `/jitneuro-update` and it just happens. Thin wrapper over the update skill; introduces no new logic.

## Risk
Zero -- documentation/command template only. Generic / owner-neutral per the open-source project rule (no owner-specific names or paths).

## Follow-ups
- Bump the root `CLAUDE.md` command count (17 -> 18 commands; 22 -> 23 files) + add `jitneuro-update` to the command list.

## Related
- `skills/update/SKILL.md` -- the update contract this command wraps
- `templates/commands/onboard.md` -- command format reference
