### PR TITLE
fix(install): never overwrite user-accumulated cognition knowledge or config

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -453,17 +453,39 @@ if ((Get-ChildItem $horizonDir -File -ErrorAction SilentlyContinue).Count -eq 0)
 Write-Host "Installing cognition layer..." -ForegroundColor Green
 $cogDir = Join-Path $Target "cognition"
 $cogDecDir = Join-Path $cogDir "decisions"
+# User-ACCUMULATED cognition files (anti-patterns.md, written by /learn) are seeded only
+# if absent and NEVER overwritten. Framework cognition files update like rules: a user
+# edit is backed up to .jitneuro-backup\cognition\ before the new version lands.
+$CogPreserve = @("anti-patterns.md")
+function Install-CognitionFile($srcFull, $name, $rel, $destDir) {
+    $dest = Join-Path $destDir $name
+    if (Test-Path $dest) {
+        if ((Get-FileHash $srcFull).Hash -ne (Get-FileHash $dest).Hash) {
+            if ($OldManifest.ContainsKey($rel) -and $OldManifest[$rel] -ne (Get-JnSha $dest)) {
+                $bdir = Join-Path $Target ".jitneuro-backup\cognition"
+                if (-not (Test-Path $bdir)) { New-Item -ItemType Directory -Path $bdir -Force | Out-Null }
+                Copy-Item $dest (Join-Path $bdir $name) -Force
+                Write-Host "  BACKUP: $rel (your edit saved to .jitneuro-backup\cognition\)"
+            }
+            Copy-Item $srcFull $dest -Force
+        }
+    } else {
+        Copy-Item $srcFull $dest
+    }
+}
 foreach ($f in (Get-ChildItem (Join-Path $Templates "cognition") -Filter "*.md" -File -ErrorAction SilentlyContinue)) {
-    Copy-Item $f.FullName (Join-Path $cogDir $f.Name) -Force
+    if ($CogPreserve -contains $f.Name) {
+        $dest = Join-Path $cogDir $f.Name
+        if (Test-Path $dest) { Write-Host "  Preserved cognition\$($f.Name) (your accumulated knowledge)" -ForegroundColor Yellow }
+        else { Copy-Item $f.FullName $dest; Write-Host "  cognition\$($f.Name) (seeded -- yours to accumulate via /learn)" }
+    } else {
+        Install-CognitionFile $f.FullName $f.Name "cognition/$($f.Name)" $cogDir
+    }
 }
 foreach ($f in (Get-ChildItem (Join-Path $Templates "cognition\decisions") -Filter "*.md" -File -ErrorAction SilentlyContinue)) {
-    Copy-Item $f.FullName (Join-Path $cogDecDir $f.Name) -Force
+    Install-CognitionFile $f.FullName $f.Name "cognition/decisions/$($f.Name)" $cogDecDir
 }
-Write-Host "  cognition\personas.md (16 personas)"
-Write-Host "  cognition\friction-detection.md"
-Write-Host "  cognition\anti-patterns.md (seed entries)"
-$decCount = (Get-ChildItem (Join-Path $Templates "cognition\decisions") -Filter "*.md" -File -ErrorAction SilentlyContinue).Count
-Write-Host "  cognition\decisions\ ($decCount models)"
+Write-Host "  cognition\ (framework updated; your edits backed up, accumulated knowledge preserved)"
 $ownerPersona = Join-Path $cogDir "owner-persona.md"
 if (-not (Test-Path $ownerPersona)) {
     Copy-Item (Join-Path $Templates "cognition\owner-persona.example.md") $ownerPersona
@@ -508,15 +530,22 @@ foreach ($hook in $hookFiles) {
     Write-Host "  hooks\$($hook.Name)"
 }
 
-# --- Copy jitneuro.json config ---
-# Preserve a previously configured knowledge catalog root across re-installs.
+# --- Install jitneuro.json config (preserve the user's settings on re-install) ---
+# Fresh install copies the template. A re-install PRESERVES the user's jitneuro.json in
+# full (scheduledAgents, team config, knowledgeRoot, any custom keys) and only bumps the
+# version field -- never clobbering user config with template defaults.
 $script:PrevKr = ""
 $installedJson = Join-Path $Target "jitneuro.json"
 if (Test-Path $installedJson) {
     try { $script:PrevKr = (Get-Content $installedJson -Raw | ConvertFrom-Json).knowledgeRoot } catch { }
+    $jraw = Get-Content $installedJson -Raw
+    $jraw = [regex]::Replace($jraw, '("version"\s*:\s*)"[^"]*"', "`$1`"$Version`"")
+    Set-Content $installedJson $jraw -NoNewline
+    Write-Host "Preserved your jitneuro.json (version -> v$Version; your settings kept)"
+} else {
+    Copy-Item $ConfigFile $installedJson -Force
+    Write-Host "Installed jitneuro.json (v$Version)"
 }
-Copy-Item $ConfigFile (Join-Path $Target "jitneuro.json") -Force
-Write-Host "Installed jitneuro.json (v$Version)"
 
 # --- Configure KNOWLEDGE_ROOT (always present; local store auto-created) ---
 Configure-KnowledgeRoot

--- a/install.sh
+++ b/install.sh
@@ -472,18 +472,44 @@ fi
 
 # Install cognition layer (Phase 2)
 echo "Installing cognition layer..."
+# User-ACCUMULATED cognition files (anti-patterns.md, written by /learn) are seeded only
+# if absent and NEVER overwritten. Framework cognition files update like rules: a user
+# edit is backed up to .jitneuro-backup/cognition/ before the new version lands.
+_jn_install_cog() {  # $1=src  $2=rel (e.g. cognition/foo.md)  $3=dest
+  if [ -f "$3" ]; then
+    if ! diff -q "$1" "$3" >/dev/null 2>&1; then
+      local old_sha; old_sha="$(_jn_oldsha "$2")"
+      if [ -n "$old_sha" ] && [ "$old_sha" != "$(_jn_sha "$3")" ]; then
+        mkdir -p "$TARGET/.jitneuro-backup/cognition"
+        cp "$3" "$TARGET/.jitneuro-backup/cognition/$(basename "$3")"
+        echo "  BACKUP: $2 (your edit saved to .jitneuro-backup/cognition/)"
+      fi
+      cp "$1" "$3"
+    fi
+  else
+    cp "$1" "$3"
+  fi
+}
 for cog_file in "$TEMPLATES/cognition/"*.md; do
   [ -f "$cog_file" ] || continue
-  cp "$cog_file" "$TARGET/cognition/$(basename "$cog_file")"
+  cog_name="$(basename "$cog_file")"
+  if [ "$cog_name" = "anti-patterns.md" ]; then
+    if [ -f "$TARGET/cognition/$cog_name" ]; then
+      echo "  Preserved cognition/$cog_name (your accumulated knowledge)"
+    else
+      cp "$cog_file" "$TARGET/cognition/$cog_name"
+      echo "  cognition/$cog_name (seeded -- yours to accumulate via /learn)"
+    fi
+  else
+    _jn_install_cog "$cog_file" "cognition/$cog_name" "$TARGET/cognition/$cog_name"
+  fi
 done
 for dec_file in "$TEMPLATES/cognition/decisions/"*.md; do
   [ -f "$dec_file" ] || continue
-  cp "$dec_file" "$TARGET/cognition/decisions/$(basename "$dec_file")"
+  dec_name="$(basename "$dec_file")"
+  _jn_install_cog "$dec_file" "cognition/decisions/$dec_name" "$TARGET/cognition/decisions/$dec_name"
 done
-echo "  cognition/personas.md (16 personas)"
-echo "  cognition/friction-detection.md"
-echo "  cognition/anti-patterns.md (seed entries)"
-echo "  cognition/decisions/ ($(ls -1 "$TEMPLATES/cognition/decisions/"*.md 2>/dev/null | wc -l) models)"
+echo "  cognition/ (framework updated; your edits backed up, accumulated knowledge preserved)"
 # Create owner-persona from example if it doesn't exist
 if [ ! -f "$TARGET/cognition/owner-persona.md" ]; then
   cp "$TEMPLATES/cognition/owner-persona.example.md" "$TARGET/cognition/owner-persona.md"
@@ -539,14 +565,20 @@ case "$(uname -s)" in
     ;;
 esac
 
-# --- Copy jitneuro.json config ---
-# Preserve a previously configured knowledge catalog root across re-installs.
+# --- Install jitneuro.json config (preserve the user's settings on re-install) ---
+# Fresh install copies the template. A re-install PRESERVES the user's jitneuro.json in
+# full (scheduledAgents, team config, knowledgeRoot, any custom keys) and only bumps the
+# version field -- never clobbering user config with template defaults.
 PREV_KR=""
 if [ -f "$TARGET/jitneuro.json" ]; then
   PREV_KR=$(grep -o '"knowledgeRoot"[[:space:]]*:[[:space:]]*"[^"]*"' "$TARGET/jitneuro.json" | head -1 | sed 's/.*"knowledgeRoot"[[:space:]]*:[[:space:]]*"//;s/"$//')
+  _jn_jtmp="$(mktemp 2>/dev/null || echo "$TARGET/jitneuro.json.tmp.$$")"
+  sed -E "s/(\"version\"[[:space:]]*:[[:space:]]*\")[^\"]*\"/\1$VERSION\"/" "$TARGET/jitneuro.json" > "$_jn_jtmp" && mv "$_jn_jtmp" "$TARGET/jitneuro.json"
+  echo "Preserved your jitneuro.json (version -> v$VERSION; your settings kept)"
+else
+  cp "$TEMPLATES/jitneuro.json" "$TARGET/jitneuro.json"
+  echo "Installed jitneuro.json (v$VERSION)"
 fi
-cp "$TEMPLATES/jitneuro.json" "$TARGET/jitneuro.json"
-echo "Installed jitneuro.json (v$VERSION)"
 
 # --- Configure KNOWLEDGE_ROOT (always present; local store auto-created) ---
 configure_knowledge_root


### PR DESCRIPTION
## What
Stops the installer from silently destroying user-created knowledge / config on re-install (which is what `/jitneuro-update` runs).

## The bug
Re-running `install.ps1` / `install.sh` **force-overwrote**:
- `cognition/anti-patterns.md` -- the file `/learn` accumulates into -- with the seed template (no backup)
- `cognition/personas.md`, `friction-detection.md`, `decisions/*` (no backup)
- `jitneuro.json` -- replaced with the template, losing user keys (e.g. `scheduledAgents`)

A user who follows the rules and accumulates knowledge would lose it on the next update.

## The fix (install.ps1 + install.sh, mirrored)
- `anti-patterns.md`: seed only if absent; **never overwritten** (user-accumulated).
- Other cognition files: update like rules -- a user edit is backed up to `.jitneuro-backup/cognition/` before the new version lands.
- `jitneuro.json`: on re-install, **preserve the user's file in full** (scheduledAgents, team, knowledgeRoot, custom keys); only bump the `version` field.

The seed-only-if-empty protection already in place for engrams / bundles / horizon / owner-persona / `.knowledge` is unchanged and verified safe.

## Test plan (E2E -- both installers, evidence)
- [x] Fresh install -> append a `/learn` marker to `anti-patterns.md` + edit `personas.md` + add a custom `jitneuro.json` key -> re-install (method: ran `install.ps1` and `install.sh` twice in an isolated temp target with USERPROFILE/HOME overridden)
- [x] `anti-patterns.md` marker still present (preserved) -- both installers
- [x] `personas.md` edit backed up to `.jitneuro-backup/cognition/` and recoverable -- both
- [x] `jitneuro.json` user key preserved + still valid JSON -- both
- [x] install.ps1 parses clean; install.sh `bash -n` clean

## Risk
Install-path behavior change, fully tested. No template content changes.
